### PR TITLE
Reorganize documentation: move rules to code, add agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+Agent-facing project doc. `CLAUDE.md` in the repo root is a symlink to
+this file, so both names resolve to the same content — different tools
+look for different filenames. Edit either, you edit both.
+
+## Docs must not repeat what the code already says
+
+A doc paragraph that restates code behavior — a rule's mechanics, a
+formula, a constant's default, resolution order — is a second copy that
+goes stale silently, and the reader can't tell which copy is
+authoritative. `engine/` is the single source of truth for the game
+rules; split everything else by ownership:
+
+- **Code (doc comments)** owns "what is implemented and how".
+  Mechanics, formulas, and constants live as rustdoc on the items that
+  implement them (`Config` documents every rule knob and its default,
+  `GameState::step` documents turn resolution and combat), together
+  with the local one-or-two-sentence rationale. If you're about to
+  write a doc paragraph describing behavior, put it in a doc comment
+  instead and have the doc point at the item by name.
+- **Docs (`README.md`, `DESIGN.md`)** own what code cannot show:
+  design goals, decisions and their rationale — especially departures
+  from the original game (`old/README.md`) — what is deliberately
+  *not* implemented and why, observed emergent behavior from
+  bot-vs-bot runs, planned work, and open questions. The
+  "Differences from the original" table in `DESIGN.md` is the
+  reference example.
+
+Cross-references go by name: docs name files, types, and functions
+(`engine/src/game.rs`, `Config::growth_divisor`); a code comment whose
+"why" spans modules points at a `DESIGN.md` section by heading, as the
+`game.rs` module doc does. When renaming a doc heading or a named
+item, grep the other side for references to it.
+
+Don't paste code or values into docs — formulas, defaults, sample CLI
+invocations excepted (`README.md` usage lines are commands to copy,
+not a copy of source). Link to the item instead; a pasted copy is
+guaranteed to drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,45 +13,23 @@ small, discrete action space.
 
 ## Ruleset (v1, implemented in `engine/`)
 
-World
-- Hexagonal map of radius `R` (3R²+3R+1 tiles), cube coordinates.
-- A tile has: owner (or neutral), army count, resource count.
-- Every tile grows resources each turn:
-  `growth = max(1, (resource_cap − resources) / growth_divisor)` —
-  fast when poor, asymptotically slow near the cap. This is the
-  anti-snowball mechanic: a big empire's tiles are rich and grow slowly,
-  a recovering player's tiles grow quickly.
+`engine/src/game.rs` is the source of truth for the mechanics and their
+constants: `Config` documents every rule knob and its default, `Order`
+the two order kinds and the one-order-per-source-tile rule,
+`GameState::step` turn resolution and combat, `GameState::outcome`
+elimination and victory. Map geometry (hexagonal, cube coordinates) is
+`engine/src/coords.rs`. This doc doesn't repeat any of that; it records
+the two cross-cutting intents no single item can show:
 
-Turns
-- Simultaneous: each player submits up to `orders_per_turn` orders
-  (default 3); all resolve in the same tick. This is the command-point
-  idea from the original design, discretized into an order budget.
-  Orders are taken in submitted order until the budget is spent;
-  illegal orders are dropped without consuming budget.
-- Orders (**at most one order per source tile per turn**, of either kind):
-  - **Move** `(tile, direction, all|half)` — send armies to an *adjacent*
-    tile.
-  - **Recruit** `(tile)` — convert all of a tile's resources into armies.
-- Resolution within a tick: all orders apply "at once" (departures leave,
-  recruits raise), then everything lands and fights, then resources grow.
-  The one-order-per-tile rule means recruited armies defend the same turn
-  but cannot move until the next turn.
-
-Combat (single-step, deterministic)
-- All armies arriving on a tile plus its garrison form per-player parties.
-- The defender's party — garrison plus any same-owner arrivals — gets a
-  defense bonus (default 1.25×).
-- The strongest party survives, paying the summed effective strength of
-  all other parties; ties annihilate everyone. Survivors are converted
-  back from effective to actual units, rounding down.
-
-Victory
-- A player with no tiles is eliminated.
-- At `max_turns`, most tiles wins; ties are draws.
-
-Players
-- 2 to 6, one map corner each (opposite corners for 2, evenly spread as
-  the six corners allow otherwise). Neutral tiles never hold armies.
+- The resource growth curve (`Config::growth_divisor`) is the
+  anti-snowball mechanic at the empire scale: a big empire's tiles sit
+  near the cap and grow slowly, while a recovering player's poor tiles
+  grow quickly — losing ground speeds your economy up instead of
+  ending the game.
+- The flat order budget (`Config::orders_per_turn`) is the original
+  design's command-point idea discretized: order quality over click
+  speed, without the earn/accumulate/spend bookkeeping (see the table
+  below).
 
 ## Differences from the original (old/README.md) and why
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ issues a small budget of orders; all orders resolve at once. Tiles passively
 accumulate resources (quickly when poor, slowly when rich — growth works
 against snowballing), and resources can be converted into armies.
 
-The full ruleset and its rationale live in [DESIGN.md](DESIGN.md). The
-original Django/Vue multiplayer prototype is preserved under [`old/`](old/)
-as a reference implementation.
+The rules are documented where they are implemented, in
+[`engine/`](engine/); their rationale and design history live in
+[DESIGN.md](DESIGN.md). The original Django/Vue multiplayer prototype is
+preserved under [`old/`](old/) as a reference implementation.
 
 ## Layout
 


### PR DESCRIPTION
## Summary
Restructure project documentation to establish a clear separation of concerns: game rules and mechanics belong in code (as rustdoc), while design rationale and decisions belong in markdown docs. This reduces duplication and ensures a single source of truth.

## Key Changes

- **DESIGN.md**: Removed detailed ruleset descriptions (world, turns, combat, victory conditions) that duplicate code. Replaced with high-level design intents that code alone cannot express: the anti-snowball resource growth mechanic and the flat order budget philosophy.

- **README.md**: Updated to direct readers to `engine/` for rule documentation instead of DESIGN.md, clarifying the documentation hierarchy.

- **AGENTS.md** (new): Added comprehensive guide for agent/tool developers explaining the documentation philosophy:
  - Code (rustdoc) owns "what is implemented and how"
  - Docs own design goals, decisions, rationale, and departures from the original
  - Establishes cross-reference conventions (by name, not copy-paste)
  - Prevents silent drift of duplicated information

- **CLAUDE.md** (new): Symlink to AGENTS.md for tool compatibility (different tools search for different filenames).

## Notable Details

The reorganization establishes that `engine/src/game.rs` (`Config`, `Order`, `GameState::step`, `GameState::outcome`) and `engine/src/coords.rs` are the authoritative sources for game mechanics, with DESIGN.md serving as a higher-level reference for design philosophy and historical context rather than a rules reference.

https://claude.ai/code/session_01MZbKwxjPnnjjdfx38q7jde