### PR TITLE
Add CI workflow and refactor tile ownership check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Format, lint and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace --locked

--- a/bot/src/lib.rs
+++ b/bot/src/lib.rs
@@ -121,9 +121,9 @@ impl Bot for GreedyBot {
             }
 
             let enemy_next_door = hex.neighbors().any(|(_, n)| {
-                state.tile(n).map_or(false, |t| {
-                    t.owner.is_some() && t.owner != Some(me) && t.army > 0
-                })
+                state
+                    .tile(n)
+                    .is_some_and(|t| t.owner.is_some_and(|o| o != me) && t.army > 0)
             });
 
             // Recruit when threatened, or whenever a tile has piled up

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -1,0 +1,36 @@
+//! End-to-end check of the compiled binary: arg parsing through match
+//! resolution to the summary line.
+
+use std::process::Command;
+
+fn overthrow() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_overthrow"))
+}
+
+#[test]
+fn match_subcommand_runs_to_completion() {
+    let output = overthrow()
+        .args(["match", "--games", "2"])
+        .output()
+        .expect("failed to spawn binary");
+    assert!(output.status.success(), "exit: {:?}", output.status);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("2 games"), "unexpected output: {stdout}");
+}
+
+#[test]
+fn unknown_arguments_are_rejected() {
+    let output = overthrow()
+        .args(["match", "--nonsense"])
+        .output()
+        .expect("failed to spawn binary");
+    assert_eq!(output.status.code(), Some(2));
+}
+
+#[test]
+fn missing_subcommand_prints_usage() {
+    let output = overthrow().output().expect("failed to spawn binary");
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("usage:"), "unexpected stderr: {stderr}");
+}


### PR DESCRIPTION
This PR adds continuous integration and makes a small code quality improvement.

**Changes:**

- **CI workflow**: Added `.github/workflows/ci.yml` to run formatting checks, linting, tests, and a smoke test of the CLI on every push to master and all pull requests
- **Code refactor**: Replaced `map_or(false, |t| ...)` with `is_some_and(|t| ...)` in `GreedyBot::decide()` for improved readability and idiomatic Rust

The CI workflow installs the Rust stable toolchain with rustfmt and clippy, uses caching for faster builds, and verifies code formatting, runs clippy with warnings-as-errors, executes the test suite, and performs a smoke test of the CLI.

https://claude.ai/code/session_01DvaYZMnS4abPhFKkxJHHxg