### PR TITLE
Add game-health metrics and determinism tests

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,16 +42,60 @@ the two cross-cutting intents no single item can show:
 | Corporations, boss trees, transfers | Omitted | Out of scope for single-player vs AI (deliberate decision, 2026-07) |
 | Army cap tied to CP cap | No cap | Keep constants minimal; revisit if unbounded stacks distort play |
 
-## Observed behavior (bot-vs-bot, defaults)
+## How we know it works as a game
 
-- `greedy` beats `random` 200/200 on radius 5, avg ~86 turns.
-- Mirror matches (`greedy,greedy`, `random,random`) are ~50/50 with no
-  first-player advantage — the setup is symmetric and turns are truly
-  simultaneous.
-- `greedy` mirrors usually hit `max_turns` (turtling stalemate). Expected
-  with a defense bonus and no economic pressure to attack; worth revisiting
-  once a real frontend or smarter bots exist. Possible levers: victory by
-  resource share, decay on huge stacks, or attack efficiency scaling.
+The natural way to judge "this really plays like a game" is to watch it —
+render a bot match and eyeball the map evolving. That judgment is real but
+it doesn't reproduce: it isn't seeded, isn't quantified, can't be compared
+across commits, and nobody re-watches after every rule tweak, so it drifts
+silently. The goal here is to decompose that eyeball judgment into
+indicators that are **deterministic** (everything is seeded — a failure
+replays exactly), **quantified**, and **tied to the design goals** above,
+so a rule change that breaks a goal fails a named test instead of a vibe.
+(Only the measurable goals get a proxy — "no APM pressure" and "simple
+rules" are structural properties of the ruleset, not test subjects.)
+
+Two layers, split by what they can claim:
+
+- **Engine correctness** — necessary but not sufficient; a game can be
+  bug-free and still be a bad game. `engine/tests/invariants.rs` checks
+  properties that must hold in *every* reachable state of *any* game
+  (including under garbage orders), that equal seeds replay to identical
+  states (`GameState::state_hash`), and pins one golden game as a change
+  detector.
+- **Gameplay health** — proxies for the design goals, measured over
+  seeded bot series. Metric definitions live in `bot/src/stats.rs`
+  (`MatchRecord`, `SeriesStats`); `bot/tests/health.rs` asserts one loose
+  threshold per goal; the CLI prints the same metrics for ad-hoc runs.
+  The mapping: *strategy matters* → `greedy` dominates `random`, by
+  elimination rather than turn-limit adjudication; *fairness /
+  simultaneity* → seat-swap invariance and ~50/50 mirrors; *no
+  snowball* → the comeback rate (`MatchRecord::comeback`: how often the
+  quarter-mark tile leader loses anyway).
+
+Known limits, so the numbers aren't over-trusted: these are proxies, not
+proof the game is *fun*; the bots bound what the metrics can see (`random`
+can't punish anything, `greedy` turtles), so the indicators sharpen as the
+opponents do — the RL phase feeds directly back into this suite.
+Thresholds are deliberately loose change-detectors, not balance pins.
+Eyeballing rendered games remains a legitimate tool — just run it from a
+fixed `--seed` so what was seen can be seen again.
+
+## Observed behavior (bot-vs-bot, radius 5, defaults)
+
+- `greedy` beats `random` 200/200, avg ~89 turns, every win by
+  elimination.
+- Mirror matches are ~50/50 with no first-player advantage — the setup is
+  symmetric and turns are truly simultaneous.
+- *Both* mirrors always hit `max_turns` and get decided by tile-count
+  adjudication, never elimination. For `random` mirrors the quarter-mark
+  lead barely predicts the winner (comeback rate ~42%); for `greedy`
+  mirrors it predicted all 186 decided games (0 comebacks) — under a
+  turtling stalemate the early tile lead is exactly what adjudication
+  rewards. Expected with a defense bonus and no economic pressure to
+  attack; worth revisiting once a real frontend or smarter bots exist.
+  Possible levers: victory by resource share, decay on huge stacks, or
+  attack efficiency scaling.
 
 ## ML plan (next phases)
 

--- a/bot/src/lib.rs
+++ b/bot/src/lib.rs
@@ -9,24 +9,37 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use overthrow_engine::rng::Rng;
 use overthrow_engine::{Config, GameState, Hex, MoveAmount, Order, Outcome, PlayerId};
 
+pub mod stats;
+
+pub use stats::{MatchRecord, SeriesStats};
+
 pub trait Bot {
     fn name(&self) -> &'static str;
     fn orders(&mut self, state: &GameState, me: PlayerId) -> Vec<Order>;
 }
 
-/// Drive a game to completion, one `Bot` per player.
-pub fn run_match(config: Config, bots: &mut [Box<dyn Bot>]) -> (GameState, Outcome) {
+/// Drive a game to completion, one `Bot` per player, tracing what the
+/// game-health metrics need (see `stats::MatchRecord`).
+pub fn run_match(config: Config, bots: &mut [Box<dyn Bot>]) -> (GameState, MatchRecord) {
     assert_eq!(bots.len(), config.players as usize);
     let mut state = GameState::new(config);
+    let mut leaders = vec![stats::strict_leader(&state)];
     loop {
         let orders: Vec<_> = bots
             .iter_mut()
             .enumerate()
             .map(|(p, bot)| bot.orders(&state, PlayerId(p as u8)))
             .collect();
-        match state.step(&orders) {
-            Outcome::Ongoing => {}
-            outcome => return (state, outcome),
+        let outcome = state.step(&orders);
+        leaders.push(stats::strict_leader(&state));
+        if outcome != Outcome::Ongoing {
+            let record = MatchRecord {
+                outcome,
+                turns: state.turn,
+                max_turns: state.config.max_turns,
+                leaders,
+            };
+            return (state, record);
         }
     }
 }
@@ -221,34 +234,5 @@ pub fn make_bot(name: &str, seed: u64) -> Option<Box<dyn Bot>> {
         "random" => Some(Box::new(RandomBot::new(seed))),
         "greedy" => Some(Box::new(GreedyBot::new(seed))),
         _ => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn greedy_beats_random_consistently() {
-        let config = Config {
-            radius: 4,
-            max_turns: 300,
-            ..Config::default()
-        };
-        let mut greedy_wins = 0;
-        for seed in 0..10 {
-            let mut bots: Vec<Box<dyn Bot>> = vec![
-                Box::new(GreedyBot::new(seed)),
-                Box::new(RandomBot::new(seed + 1000)),
-            ];
-            let (_, outcome) = run_match(config.clone(), &mut bots);
-            if outcome == Outcome::Winner(PlayerId(0)) {
-                greedy_wins += 1;
-            }
-        }
-        assert!(
-            greedy_wins >= 8,
-            "greedy should dominate random, won {greedy_wins}/10"
-        );
     }
 }

--- a/bot/src/stats.rs
+++ b/bot/src/stats.rs
@@ -1,0 +1,179 @@
+//! Match records and series-level game-health metrics — the definitions
+//! behind `DESIGN.md` "How we know it works as a game". `MatchRecord` is
+//! the minimal per-game trace the metrics need; `SeriesStats` aggregates
+//! records into the numbers the CLI prints and `bot/tests/health.rs`
+//! asserts.
+
+use overthrow_engine::{GameState, Outcome, PlayerId};
+
+/// One completed match: its outcome plus the per-turn leader trace.
+/// `leaders[t]` is the strict tile-count leader after `t` turns have
+/// resolved (`None` = tied), so `leaders[0]` describes the initial state
+/// and `leaders[turns]` the final one.
+#[derive(Clone, Debug)]
+pub struct MatchRecord {
+    pub outcome: Outcome,
+    pub turns: u32,
+    pub max_turns: u32,
+    pub leaders: Vec<Option<PlayerId>>,
+}
+
+/// The strict tile-count leader of the current state, `None` on a tie.
+pub fn strict_leader(state: &GameState) -> Option<PlayerId> {
+    let counts: Vec<usize> = (0..state.config.players)
+        .map(|p| state.tile_count(PlayerId(p)))
+        .collect();
+    let best = *counts.iter().max().unwrap();
+    let mut leaders = counts.iter().enumerate().filter(|&(_, &c)| c == best);
+    let (player, _) = leaders.next().unwrap();
+    match leaders.next() {
+        Some(_) => None,
+        None => Some(PlayerId(player as u8)),
+    }
+}
+
+impl MatchRecord {
+    pub fn winner(&self) -> Option<PlayerId> {
+        match self.outcome {
+            Outcome::Winner(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Whether the game ended by eliminating every other player before
+    /// the turn limit, as opposed to being adjudicated (or drawn) at it.
+    /// A kill landing exactly on the limit is indistinguishable from
+    /// adjudication in the record and counts as a turn-limit ending.
+    pub fn by_elimination(&self) -> bool {
+        self.winner().is_some() && self.turns < self.max_turns
+    }
+
+    /// The strict tile-count leader at the quarter mark of the game
+    /// (`None` if tied there). The reference point for `comeback`.
+    pub fn early_leader(&self) -> Option<PlayerId> {
+        let quarter = (self.turns as usize / 4).max(1).min(self.leaders.len() - 1);
+        self.leaders[quarter]
+    }
+
+    /// Whether the eventual winner was *behind* at the quarter mark —
+    /// the anti-snowball design goal made measurable. `None` when the
+    /// game had no winner or no strict early leader.
+    pub fn comeback(&self) -> Option<bool> {
+        Some(self.winner()? != self.early_leader()?)
+    }
+}
+
+/// Aggregated game-health metrics over a series of matches.
+#[derive(Clone, Debug, Default)]
+pub struct SeriesStats {
+    pub games: u32,
+    /// Wins per player id.
+    pub wins: Vec<u32>,
+    pub draws: u32,
+    /// Games won by eliminating every opponent (see
+    /// `MatchRecord::by_elimination`).
+    pub eliminations: u32,
+    /// Games that ran to the turn limit (adjudicated wins and draws).
+    pub turn_limit_endings: u32,
+    /// Decided games where the early leader lost (see
+    /// `MatchRecord::comeback`).
+    pub comebacks: u32,
+    /// Decided games that had a strict early leader — the denominator
+    /// for the comeback rate.
+    pub comeback_eligible: u32,
+    pub total_turns: u64,
+}
+
+impl SeriesStats {
+    pub fn record(&mut self, record: &MatchRecord) {
+        self.games += 1;
+        self.total_turns += record.turns as u64;
+        match record.winner() {
+            Some(PlayerId(p)) => {
+                if self.wins.len() <= p as usize {
+                    self.wins.resize(p as usize + 1, 0);
+                }
+                self.wins[p as usize] += 1;
+            }
+            None => self.draws += 1,
+        }
+        if record.by_elimination() {
+            self.eliminations += 1;
+        } else if record.turns >= record.max_turns {
+            self.turn_limit_endings += 1;
+        }
+        if let Some(comeback) = record.comeback() {
+            self.comeback_eligible += 1;
+            if comeback {
+                self.comebacks += 1;
+            }
+        }
+    }
+
+    pub fn wins_of(&self, player: PlayerId) -> u32 {
+        self.wins.get(player.0 as usize).copied().unwrap_or(0)
+    }
+
+    pub fn avg_turns(&self) -> u64 {
+        self.total_turns / self.games.max(1) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(outcome: Outcome, leaders: Vec<Option<PlayerId>>) -> MatchRecord {
+        MatchRecord {
+            outcome,
+            turns: leaders.len() as u32 - 1,
+            max_turns: 100,
+            leaders,
+        }
+    }
+
+    #[test]
+    fn comeback_is_winner_behind_at_quarter_mark() {
+        let p0 = Some(PlayerId(0));
+        let p1 = Some(PlayerId(1));
+        // 8 turns; quarter mark = turn 2, where p1 leads.
+        let leaders = vec![None, p0, p1, p1, p1, p0, p0, p0, p0];
+        assert_eq!(
+            record(Outcome::Winner(PlayerId(0)), leaders.clone()).comeback(),
+            Some(true)
+        );
+        assert_eq!(
+            record(Outcome::Winner(PlayerId(1)), leaders.clone()).comeback(),
+            Some(false)
+        );
+        assert_eq!(record(Outcome::Draw, leaders).comeback(), None);
+        // Tied at the quarter mark: no reference point, not eligible.
+        let tied = vec![None, None, None, None, None, p0, p0, p0, p0];
+        assert_eq!(record(Outcome::Winner(PlayerId(0)), tied).comeback(), None);
+    }
+
+    #[test]
+    fn series_stats_classify_endings() {
+        let p0 = Some(PlayerId(0));
+        let p1 = Some(PlayerId(1));
+        let mut stats = SeriesStats::default();
+        // Elimination win with a comeback (p1 led the quarter mark).
+        stats.record(&record(
+            Outcome::Winner(PlayerId(0)),
+            vec![None, p1, p1, p1, p0, p0, p0, p0, p0],
+        ));
+        // Turn-limit draw.
+        stats.record(&MatchRecord {
+            outcome: Outcome::Draw,
+            turns: 100,
+            max_turns: 100,
+            leaders: vec![None; 101],
+        });
+        assert_eq!(stats.games, 2);
+        assert_eq!(stats.wins_of(PlayerId(0)), 1);
+        assert_eq!(stats.draws, 1);
+        assert_eq!(stats.eliminations, 1);
+        assert_eq!(stats.turn_limit_endings, 1);
+        assert_eq!((stats.comebacks, stats.comeback_eligible), (1, 1));
+    }
+}

--- a/bot/tests/health.rs
+++ b/bot/tests/health.rs
@@ -1,0 +1,94 @@
+//! Seeded gameplay-health suite: end-to-end indicators that the ruleset
+//! works *as a game*, one test per design goal — see `DESIGN.md` ("How we
+//! know it works as a game") for the approach and its limits. Every game
+//! is seeded, so failures replay exactly. Thresholds are deliberately
+//! loose: they catch a rule change that breaks a goal outright, not
+//! balance drift.
+
+use overthrow_bot::{make_bot, run_match, Bot, SeriesStats};
+use overthrow_engine::{Config, PlayerId};
+
+fn config() -> Config {
+    Config {
+        radius: 4,
+        max_turns: 300,
+        ..Config::default()
+    }
+}
+
+/// Run `games` seeded matches of `bots.0` (P0) vs `bots.1` (P1).
+fn run_series(bots: (&str, &str), games: u64) -> SeriesStats {
+    let mut stats = SeriesStats::default();
+    for seed in 0..games {
+        let mut players: Vec<Box<dyn Bot>> = [bots.0, bots.1]
+            .iter()
+            .enumerate()
+            .map(|(i, name)| make_bot(name, seed * 2 + i as u64).unwrap())
+            .collect();
+        let (_, record) = run_match(config(), &mut players);
+        stats.record(&record);
+    }
+    stats
+}
+
+/// Strategy must matter: the scripted heuristic dominates the random
+/// baseline, and does so by actually eliminating it, not by out-waiting
+/// the turn limit.
+#[test]
+fn greedy_dominates_random_by_elimination() {
+    let stats = run_series(("greedy", "random"), 20);
+    let greedy_wins = stats.wins_of(PlayerId(0));
+    assert!(
+        greedy_wins >= 18,
+        "greedy should dominate random, won {greedy_wins}/20"
+    );
+    assert!(
+        stats.eliminations >= 18,
+        "wins should come by elimination, got {}/20",
+        stats.eliminations
+    );
+}
+
+/// Fairness: strength must not depend on seat order. The setup is
+/// symmetric and turns resolve simultaneously, so greedy must dominate
+/// random equally as P0 and as P1.
+#[test]
+fn strength_is_seat_independent() {
+    let as_p0 = run_series(("greedy", "random"), 10).wins_of(PlayerId(0));
+    let as_p1 = run_series(("random", "greedy"), 10).wins_of(PlayerId(1));
+    assert!(
+        as_p0 >= 8 && as_p1 >= 8,
+        "greedy should dominate from either seat, won {as_p0}/10 as P0, {as_p1}/10 as P1"
+    );
+}
+
+/// Fairness: a mirror match must be roughly 50/50 — no seat holds a
+/// structural advantage.
+#[test]
+fn mirror_match_has_no_seat_advantage() {
+    let stats = run_series(("random", "random"), 40);
+    let (p0, p1) = (stats.wins_of(PlayerId(0)), stats.wins_of(PlayerId(1)));
+    let decided = p0 + p1;
+    assert!(decided >= 20, "too few decided games ({decided}/40)");
+    assert!(
+        p0 * 4 <= decided * 3 && p1 * 4 <= decided * 3,
+        "seat advantage: {p0} vs {p1} of {decided} decided games"
+    );
+}
+
+/// Anti-snowball: leading at the quarter mark must not lock in the win.
+/// If comebacks never happen, the growth curve isn't doing its job.
+#[test]
+fn early_lead_does_not_lock_the_win() {
+    let stats = run_series(("random", "random"), 40);
+    assert!(
+        stats.comeback_eligible >= 10,
+        "too few eligible games ({})",
+        stats.comeback_eligible
+    );
+    assert!(
+        stats.comebacks > 0,
+        "no comebacks in {} eligible games: early lead looks decisive",
+        stats.comeback_eligible
+    );
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,8 +8,8 @@
 use std::env;
 use std::process::exit;
 
-use overthrow_bot::{make_bot, run_match, Bot};
-use overthrow_engine::{Config, GameState, Hex, Outcome, PlayerId};
+use overthrow_bot::{make_bot, run_match, Bot, SeriesStats};
+use overthrow_engine::{Config, GameState, Hex, PlayerId};
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -61,9 +61,7 @@ fn main() {
         ..Config::default()
     };
 
-    let mut wins = [0u32; 2];
-    let mut draws = 0u32;
-    let mut total_turns = 0u64;
+    let mut stats = SeriesStats::default();
 
     for game_index in 0..games {
         let game_seed = seed + game_index as u64;
@@ -80,19 +78,13 @@ fn main() {
             })
             .collect();
 
-        let (state, outcome) = run_match(config.clone(), &mut players);
-
-        total_turns += state.turn as u64;
-        match outcome {
-            Outcome::Winner(PlayerId(p)) => wins[p as usize] += 1,
-            Outcome::Draw => draws += 1,
-            Outcome::Ongoing => unreachable!(),
-        }
+        let (state, record) = run_match(config.clone(), &mut players);
+        stats.record(&record);
 
         if render {
             println!(
                 "game {game_index}: {:?} after {} turns  ({} vs {})",
-                outcome, state.turn, bots.0, bots.1
+                record.outcome, state.turn, bots.0, bots.1
             );
             print_map(&state);
         }
@@ -103,11 +95,15 @@ fn main() {
         games,
         radius,
         bots.0,
-        wins[0],
+        stats.wins_of(PlayerId(0)),
         bots.1,
-        wins[1],
-        draws,
-        total_turns / games.max(1) as u64,
+        stats.wins_of(PlayerId(1)),
+        stats.draws,
+        stats.avg_turns(),
+    );
+    println!(
+        "endings: {} by elimination, {} at the turn limit; comebacks: {} of {} decided games with an early leader",
+        stats.eliminations, stats.turn_limit_endings, stats.comebacks, stats.comeback_eligible,
     );
 }
 

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -177,6 +177,31 @@ impl GameState {
             .sum()
     }
 
+    /// FNV-1a hash of the observable state: the turn counter plus every
+    /// tile (owner, army, resources) in canonical map order. Stable across
+    /// processes, platforms and Rust versions, so equal hashes from equal
+    /// seeds are a meaningful determinism check (see
+    /// `engine/tests/invariants.rs`), and RL code can later use it for
+    /// transposition tables.
+    pub fn state_hash(&self) -> u64 {
+        let mut hash: u64 = 0xcbf29ce484222325;
+        let mut mix = |value: u64| {
+            for byte in value.to_le_bytes() {
+                hash = (hash ^ byte as u64).wrapping_mul(0x100000001b3);
+            }
+        };
+        mix(self.turn as u64);
+        for tile in &self.tiles {
+            mix(match tile.owner {
+                Some(PlayerId(p)) => p as u64 + 1,
+                None => 0,
+            });
+            mix(tile.army as u64);
+            mix(tile.resources as u64);
+        }
+        hash
+    }
+
     pub fn outcome(&self) -> Outcome {
         // One pass over the board; everything below derives from the counts.
         let mut counts = vec![0u32; self.config.players as usize];
@@ -623,37 +648,5 @@ mod tests {
         }
         let cap = s.config.resource_cap;
         assert!(s.iter_tiles().all(|(_, t)| t.resources == cap));
-    }
-
-    #[test]
-    fn random_games_terminate_and_stay_consistent() {
-        use crate::rng::Rng;
-        let mut rng = Rng::new(42);
-        for _ in 0..5 {
-            let mut s = GameState::new(Config {
-                max_turns: 200,
-                ..small_config()
-            });
-            loop {
-                let orders: Vec<Vec<Order>> = (0..s.config.players)
-                    .map(|p| {
-                        let legal = s.legal_orders(PlayerId(p));
-                        (0..s.config.orders_per_turn)
-                            .filter_map(|_| {
-                                if legal.is_empty() {
-                                    None
-                                } else {
-                                    Some(legal[rng.below(legal.len())])
-                                }
-                            })
-                            .collect()
-                    })
-                    .collect();
-                if s.step(&orders) != Outcome::Ongoing {
-                    break;
-                }
-                assert!(s.turn <= 200, "game must terminate by max_turns");
-            }
-        }
     }
 }

--- a/engine/tests/invariants.rs
+++ b/engine/tests/invariants.rs
@@ -1,0 +1,179 @@
+//! Whole-game invariant and determinism checks, driven through the public
+//! API only. Where the unit tests in `game.rs` pin individual mechanics,
+//! these tests assert properties that must hold across *every* reachable
+//! state of *any* game — the engine-level half of the game-health
+//! indicators (the gameplay half lives in `bot/tests/health.rs`).
+
+use std::collections::HashSet;
+
+use overthrow_engine::rng::Rng;
+use overthrow_engine::{Config, Direction, GameState, Hex, MoveAmount, Order, Outcome, PlayerId};
+
+fn test_config() -> Config {
+    Config {
+        radius: 3,
+        max_turns: 200,
+        ..Config::default()
+    }
+}
+
+/// Random legal orders for every player, `orders_per_turn` each.
+fn random_legal_orders(state: &GameState, rng: &mut Rng) -> Vec<Vec<Order>> {
+    (0..state.config.players)
+        .map(|p| {
+            let legal = state.legal_orders(PlayerId(p));
+            (0..state.config.orders_per_turn)
+                .filter_map(|_| {
+                    if legal.is_empty() {
+                        None
+                    } else {
+                        Some(legal[rng.below(legal.len())])
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Random orders drawn from the full order space — off-map hexes, tiles the
+/// player doesn't own, empty sources. The engine must drop these silently.
+fn random_garbage_orders(state: &GameState, rng: &mut Rng) -> Vec<Vec<Order>> {
+    let r = state.config.radius;
+    let random_hex = |rng: &mut Rng| {
+        // Sample from a box larger than the map so off-map hexes occur.
+        Hex::new(
+            rng.below((4 * r + 1) as usize) as i32 - 2 * r,
+            rng.below((4 * r + 1) as usize) as i32 - 2 * r,
+        )
+    };
+    (0..state.config.players)
+        .map(|_| {
+            (0..state.config.orders_per_turn + 2)
+                .map(|_| {
+                    let source = random_hex(rng);
+                    if rng.below(4) == 0 {
+                        Order::Recruit { at: source }
+                    } else {
+                        Order::Move {
+                            from: source,
+                            dir: Direction::ALL[rng.below(6)],
+                            amount: if rng.below(2) == 0 {
+                                MoveAmount::All
+                            } else {
+                                MoveAmount::Half
+                            },
+                        }
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Panics if any cross-state invariant is violated.
+fn check_invariants(state: &GameState, ever_owned: &mut HashSet<Hex>) {
+    for (hex, tile) in state.iter_tiles() {
+        match tile.owner {
+            None => {
+                assert_eq!(tile.army, 0, "neutral tile {hex:?} holds an army");
+                assert!(
+                    !ever_owned.contains(&hex),
+                    "tile {hex:?} reverted to neutral"
+                );
+            }
+            Some(PlayerId(p)) => {
+                assert!(
+                    p < state.config.players,
+                    "tile {hex:?} owned by out-of-range player {p}"
+                );
+                ever_owned.insert(hex);
+            }
+        }
+        assert!(
+            tile.resources <= state.config.resource_cap,
+            "tile {hex:?} exceeds the resource cap"
+        );
+    }
+    assert!(
+        state.turn <= state.config.max_turns,
+        "game ran past max_turns"
+    );
+}
+
+/// Drive seeded games to completion, checking the invariants after every
+/// step. `orders_for` picks the order stream (legal or garbage).
+fn run_checked_games(
+    seed_base: u64,
+    games: u64,
+    orders_for: fn(&GameState, &mut Rng) -> Vec<Vec<Order>>,
+) {
+    for seed in seed_base..seed_base + games {
+        let mut rng = Rng::new(seed);
+        let mut state = GameState::new(test_config());
+        let mut ever_owned = HashSet::new();
+        check_invariants(&state, &mut ever_owned);
+        loop {
+            let expected_turn = state.turn + 1;
+            let outcome = state.step(&orders_for(&state, &mut rng));
+            assert_eq!(state.turn, expected_turn, "turn must advance by one");
+            check_invariants(&state, &mut ever_owned);
+            match outcome {
+                Outcome::Ongoing => assert!(
+                    state.turn < state.config.max_turns,
+                    "game still ongoing at max_turns"
+                ),
+                _ => break,
+            }
+        }
+    }
+}
+
+#[test]
+fn invariants_hold_through_random_legal_games() {
+    run_checked_games(0, 10, random_legal_orders);
+}
+
+#[test]
+fn garbage_orders_never_panic_or_break_invariants() {
+    run_checked_games(100, 10, random_garbage_orders);
+}
+
+#[test]
+fn same_seed_replays_to_identical_states() {
+    let play = |seed: u64| -> Vec<u64> {
+        let mut rng = Rng::new(seed);
+        let mut state = GameState::new(test_config());
+        let mut hashes = vec![state.state_hash()];
+        while state.step(&random_legal_orders(&state, &mut rng)) == Outcome::Ongoing {
+            hashes.push(state.state_hash());
+        }
+        hashes.push(state.state_hash());
+        hashes
+    };
+    for seed in 0..3 {
+        assert_eq!(
+            play(seed),
+            play(seed),
+            "same seed must replay to the same per-turn state hashes"
+        );
+    }
+}
+
+/// Change detector: the exact final state of one fixed seeded game. Any
+/// change to the rules, `legal_orders` ordering, or the RNG moves this
+/// value — that's the point. Update the constant deliberately when a rule
+/// change is intended, never to silence an unexpected failure.
+#[test]
+fn golden_game_final_state_is_pinned() {
+    let mut rng = Rng::new(42);
+    let mut state = GameState::new(test_config());
+    while state.step(&random_legal_orders(&state, &mut rng)) == Outcome::Ongoing {}
+    assert_eq!(
+        (state.turn, state.state_hash()),
+        (GOLDEN_TURNS, GOLDEN_HASH),
+        "engine behavior changed; if intended, update the golden values"
+    );
+}
+
+const GOLDEN_TURNS: u32 = 200;
+const GOLDEN_HASH: u64 = 82906542146445830;


### PR DESCRIPTION
Decompose the "does this play like a game" judgment into deterministic, quantified indicators tied to design goals. This adds two test suites and supporting infrastructure:

**Engine correctness** (`engine/tests/invariants.rs`):
- Invariant checks that must hold in every reachable state (no tile reverts to neutral, no out-of-range owners, resource caps respected, turn counter advances correctly)
- Determinism verification: equal seeds replay to identical `state_hash()` values
- Garbage-order robustness: engine silently drops invalid orders without panicking
- Golden-game change detector: pins one seeded game's final state as a regression test

**Gameplay health** (`bot/tests/health.rs`):
- Four seeded bot-series tests, one per design goal: strategy matters (greedy dominates random by elimination), fairness (seat-swap invariance and ~50/50 mirrors), no snowball (comeback rate when early leader loses)
- Thresholds are deliberately loose change-detectors, not balance pins

**Supporting changes**:
- New `bot/src/stats.rs` module: `MatchRecord` (per-game trace with outcome and per-turn leader snapshots), `SeriesStats` (aggregated metrics), `strict_leader()` helper, and `comeback()` calculation
- `GameState::state_hash()`: FNV-1a hash of turn counter and all tiles for determinism checks and future RL transposition tables
- `run_match()` now returns `MatchRecord` instead of bare `Outcome`, capturing the leader trace needed for metrics
- CLI updated to print ending classification (elimination vs turn-limit) and comeback rate alongside existing win/draw counts
- Moved old inline test from `bot/src/lib.rs` into the new `bot/tests/health.rs` suite with expanded coverage

The metrics are proxies, not proof of fun — they sharpen as bot strength improves and eyeballing rendered games (from fixed `--seed`) remains valid. See `DESIGN.md` "How we know it works as a game" for the full approach and known limits.

https://claude.ai/code/session_011GHy6doBTWVb98JCCgkYTj