### PR TITLE
CI: trigger on main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Switch the CI workflow's push trigger from `master` to `main`, since the default branch is moving to `main`.

**Changes:**
- `.github/workflows/ci.yml`: `push: branches: [master]` → `branches: [main]`

The `pull_request` trigger is unchanged, so PRs keep getting CI regardless of base branch.

https://claude.ai/code/session_018adpLy24Dh8N7Q5XFLPHPa