### PR TITLE
Add TODO.md and document technical debt tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,12 @@ Don't paste code or values into docs — formulas, defaults, sample CLI
 invocations excepted (`README.md` usage lines are commands to copy,
 not a copy of source). Link to the item instead; a pasted copy is
 guaranteed to drift.
+
+## Tracking debt you notice in passing
+
+When you spot a rough edge while working on something else — a refactor,
+a dead branch, drifted duplication, a missing test — log it in `TODO.md`
+at the repo root instead of fixing it now (scope creep) or burying an
+inline `// TODO` (invisible outside that file). Glance at `TODO.md`
+before starting new work; its header has the convention. Game-design
+questions are not debt: they go to `DESIGN.md`, next to their rationale.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,19 @@
+# TODO
+
+A running registry of open technical debt — things worth improving but outside the scope of whatever is currently being worked on. Spot a rough edge while working on something else — a sketchy pattern, a dead branch, drifted duplication, a missing test? Log it here instead of fixing it inline (scope creep) or burying a `// TODO` in code (invisible outside that file). Glance at this file before starting new work; it doubles as a map of where the rough edges are.
+
+Registry, not changelog: when an entry is resolved — or turns out to be wrong or outdated — delete it in the same commit. Never strike it through or mark it "done"; git history is the changelog. The file only ever contains open items.
+
+One paragraph per entry, separated by blank lines — no bullets, no numbering, no headings. Adding or removing an entry then yields a clean, minimal diff that doesn't reflow its neighbors. Write each entry concretely enough that someone can pick it up cold, and name a concrete next move — what the fix would actually look like. "Verify someday" is a hope, not a next move.
+
+Belongs here: refactors, dead code, inconsistencies, missing tests, sketchy patterns. Does not: game-design questions, balance levers, and planned features — those are design work and live in `DESIGN.md` (planned work and open questions), next to their rationale. Prefer behavior-preserving noticings; when an entry implies a behavior change, say so, since it will need sign-off.
+
+---
+
+`cli/src/main.rs` handles bad flag values inconsistently: a non-numeric `--games`, `--radius`, or `--seed` panics through `expect` (a raw Rust panic message with a backtrace hint), while every other user error in the same parser — missing value, unknown flag, malformed `--bots` — prints a one-line message and exits with code 2. Next move: replace the three `expect` calls with the `eprintln!` + `exit(2)` shape their neighbors already use, and pin the exit code with a case in `cli/tests/cli.rs` alongside `unknown_arguments_are_rejected`.
+
+The bot-name list lives in three places: `make_bot` in `bot/src/lib.rs` is the actual registry, and `cli/src/main.rs` repeats it twice as prose — the module doc's "Bots: greedy, random." and the unknown-bot error's "(available: greedy, random)". The usage line is likewise written out twice (module doc and the `eprintln!`). Adding a bot updates one match arm and silently strands the strings. Next move: export a name list next to `make_bot` (e.g. `pub const BOT_NAMES: &[&str]`), build the CLI error message from it, and have the doc comments point at `make_bot` instead of enumerating.
+
+The engine supports 2–6 players (`Config::players`) and the surrounding code is already player-count-generic (`SeriesStats::wins` is per-id, `print_map` letters owners from `A`), but the CLI hardcodes two: `--bots` insists on exactly two comma-separated names, `config.players` stays at the default, and the summary line prints only P0 and P1. Next move: parse `--bots` as N names, set `config.players` from the count, and loop the summary over players. Behavior change (new CLI surface), but additive.
+
+`Rng::below` in `engine/src/rng.rs` documents "uniform value in `0..bound`" but computes `next_u64() % bound`, which is modulo-biased for bounds that don't divide 2^64 — negligible at the tiny bounds the bot shuffles use, but the doc overpromises. Next move: either soften the doc to say the bias is accepted, or debias (rejection sampling / Lemire); prefer the latter before anything RL-side starts drawing from this RNG, since it would silently skew exploration.


### PR DESCRIPTION
Establish a centralized registry for tracking technical debt and rough edges discovered during development, with clear conventions to keep it actionable and maintainable.

## Changes

- **Added `TODO.md`** at repo root with:
  - Header explaining the purpose and conventions (registry, not changelog; one paragraph per entry; concrete next moves)
  - Distinction between what belongs here (refactors, dead code, inconsistencies, missing tests, sketchy patterns) vs. design work (which goes in `DESIGN.md`)
  - Four initial entries documenting rough edges:
    1. Inconsistent error handling in CLI flag parsing (panics vs. clean exits)
    2. Bot-name list duplicated across three locations
    3. CLI hardcoded for two players despite engine supporting 2–6
    4. `Rng::below` modulo bias not documented or debiased

- **Updated `AGENTS.md`** with a new "Tracking debt you notice in passing" section directing contributors to log rough edges in `TODO.md` rather than fixing inline or burying `// TODO` comments, and clarifying that design questions belong in `DESIGN.md` instead.

## Rationale

This establishes a visible, centralized place to capture technical debt without scope creep (fixing it now) or invisibility (inline comments). The convention of deleting resolved entries rather than striking them through keeps the file as a current map of rough edges and lets git history serve as the changelog. The four initial entries are concrete enough to pick up cold and name specific next moves, serving as examples of the expected format.

https://claude.ai/code/session_01G4VeqrxTHhe9AcKMQVzVwi