### PR TITLE
Add lead volatility metric to measure game competitiveness

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,7 +71,10 @@ Two layers, split by what they can claim:
   elimination rather than turn-limit adjudication; *fairness /
   simultaneity* → seat-swap invariance and ~50/50 mirrors; *no
   snowball* → the comeback rate (`MatchRecord::comeback`: how often the
-  quarter-mark tile leader loses anyway).
+  quarter-mark tile leader loses anyway) is the thresholded proxy, backed
+  by lead volatility (`MatchRecord::lead_changes`), an observed-only
+  companion that reads the whole trajectory instead of one point and so
+  catches a lead that stays locked in even when the finish is close.
 
 Known limits, so the numbers aren't over-trusted: these are proxies, not
 proof the game is *fun*; the bots bound what the metrics can see (`random`
@@ -89,13 +92,17 @@ fixed `--seed` so what was seen can be seen again.
   symmetric and turns are truly simultaneous.
 - *Both* mirrors always hit `max_turns` and get decided by tile-count
   adjudication, never elimination. For `random` mirrors the quarter-mark
-  lead barely predicts the winner (comeback rate ~42%); for `greedy`
-  mirrors it predicted all 186 decided games (0 comebacks) — under a
-  turtling stalemate the early tile lead is exactly what adjudication
-  rewards. Expected with a defense bonus and no economic pressure to
-  attack; worth revisiting once a real frontend or smarter bots exist.
-  Possible levers: victory by resource share, decay on huge stacks, or
-  attack efficiency scaling.
+  lead barely predicts the winner (comeback rate ~42%) and the lead
+  changes hands constantly (~17 times per game) — noisy play keeps the
+  race open. For `greedy` mirrors it predicted all 186 decided games (0
+  comebacks) and the lead barely moves (~0.7 changes per game over 500
+  turns): under a turtling stalemate whoever grabs the early tile lead
+  holds it to the adjudicated finish. Lead volatility quantifies that
+  turtling — a near-frozen lead over a full game, where the comeback rate
+  only sees the endpoints. Expected with a defense bonus and no economic
+  pressure to attack; worth revisiting once a real frontend or smarter
+  bots exist. Possible levers: victory by resource share, decay on huge
+  stacks, or attack efficiency scaling.
 
 ## ML plan (next phases)
 

--- a/bot/src/stats.rs
+++ b/bot/src/stats.rs
@@ -61,6 +61,25 @@ impl MatchRecord {
     pub fn comeback(&self) -> Option<bool> {
         Some(self.winner()? != self.early_leader()?)
     }
+
+    /// How many times the tile-count lead changed hands over the game:
+    /// turns whose strict leader differs from the most recent earlier
+    /// turn that had one. Ties (`None`) are gaps, not changes — a lead
+    /// reclaimed by the same player after a tie doesn't count, one broken
+    /// by a *different* player does. The trajectory-wide companion to
+    /// `comeback`, which samples a single point; read at series scale by
+    /// `SeriesStats::avg_lead_changes`.
+    pub fn lead_changes(&self) -> u32 {
+        let mut changes = 0;
+        let mut held: Option<PlayerId> = None;
+        for leader in self.leaders.iter().flatten() {
+            if held.is_some_and(|h| h != *leader) {
+                changes += 1;
+            }
+            held = Some(*leader);
+        }
+        changes
+    }
 }
 
 /// Aggregated game-health metrics over a series of matches.
@@ -81,6 +100,9 @@ pub struct SeriesStats {
     /// Decided games that had a strict early leader — the denominator
     /// for the comeback rate.
     pub comeback_eligible: u32,
+    /// Total lead changes across every game (see
+    /// `MatchRecord::lead_changes`); averaged by `avg_lead_changes`.
+    pub total_lead_changes: u64,
     pub total_turns: u64,
 }
 
@@ -108,6 +130,7 @@ impl SeriesStats {
                 self.comebacks += 1;
             }
         }
+        self.total_lead_changes += record.lead_changes() as u64;
     }
 
     pub fn wins_of(&self, player: PlayerId) -> u32 {
@@ -116,6 +139,13 @@ impl SeriesStats {
 
     pub fn avg_turns(&self) -> u64 {
         self.total_turns / self.games.max(1) as u64
+    }
+
+    /// Mean lead changes per game — the series-level anti-snowball
+    /// trajectory proxy. Near zero means leads are locked in (snowball);
+    /// well above zero means the lead is genuinely contested.
+    pub fn avg_lead_changes(&self) -> f64 {
+        self.total_lead_changes as f64 / self.games.max(1) as f64
     }
 }
 
@@ -150,6 +180,23 @@ mod tests {
         // Tied at the quarter mark: no reference point, not eligible.
         let tied = vec![None, None, None, None, None, p0, p0, p0, p0];
         assert_eq!(record(Outcome::Winner(PlayerId(0)), tied).comeback(), None);
+    }
+
+    #[test]
+    fn lead_changes_count_leader_switches_treating_ties_as_gaps() {
+        let p0 = Some(PlayerId(0));
+        let p1 = Some(PlayerId(1));
+        let rec = |leaders| record(Outcome::Draw, leaders);
+        // Never-changing lead: a snowball trajectory.
+        assert_eq!(rec(vec![p0, p0, p0, p0]).lead_changes(), 0);
+        // A tie the same player reclaims is not a change.
+        assert_eq!(rec(vec![p0, None, p0]).lead_changes(), 0);
+        // A tie a different player breaks is one change.
+        assert_eq!(rec(vec![p0, None, p1]).lead_changes(), 1);
+        // Back and forth: A→B→A is two changes.
+        assert_eq!(rec(vec![None, p0, p1, p1, p0]).lead_changes(), 2);
+        // An all-tie game never has a leader, so nothing changes.
+        assert_eq!(rec(vec![None, None, None]).lead_changes(), 0);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,6 +105,11 @@ fn main() {
         "endings: {} by elimination, {} at the turn limit; comebacks: {} of {} decided games with an early leader",
         stats.eliminations, stats.turn_limit_endings, stats.comebacks, stats.comeback_eligible,
     );
+    println!(
+        "lead volatility: {:.1} lead changes per game ({} total)",
+        stats.avg_lead_changes(),
+        stats.total_lead_changes,
+    );
 }
 
 /// ASCII map: each tile is `<owner><army>`, owner A/B/. (neutral). Rows


### PR DESCRIPTION
Adds a new metric to quantify how often the tile-count lead changes hands during a game, providing a trajectory-level view of game competitiveness that complements the existing comeback rate.

## Summary

This change introduces `MatchRecord::lead_changes()` to count leader switches throughout a game, treating ties as gaps rather than changes. The metric is aggregated at the series level via `SeriesStats::total_lead_changes` and exposed as `SeriesStats::avg_lead_changes()` to show the mean lead changes per game. This addresses a gap in the existing metrics: the comeback rate only samples the game state at one point (quarter-mark), while lead volatility observes the entire trajectory and can detect when a lead stays locked in despite a close finish.

## Key changes

- **`MatchRecord::lead_changes()`**: Counts how many times the strict leader differs from the most recent earlier turn with a leader. Ties are treated as gaps, so a lead reclaimed by the same player after a tie doesn't count, but one broken by a different player does.
- **`SeriesStats`**: Added `total_lead_changes` field to accumulate lead changes across all games, and `avg_lead_changes()` method to compute the mean per game.
- **CLI output**: Added lead volatility reporting showing average lead changes per game and total across the series.
- **Documentation**: Updated `DESIGN.md` to explain lead volatility as a companion metric to comeback rate, with concrete observations from bot-vs-bot runs (e.g., `random` mirrors show ~17 changes per game vs. `greedy` mirrors at ~0.7 changes).
- **Tests**: Added comprehensive test coverage for `lead_changes()` with cases covering stable leads, ties, and back-and-forth scenarios.

## Implementation details

The `lead_changes()` implementation iterates through the `leaders` trajectory (filtering out `None` values), tracking the most recent non-tie leader and incrementing the counter whenever a different player takes the lead. This efficiently captures the full game dynamics in a single pass.

https://claude.ai/code/session_01TN6Upf6W4hHWnqTd88JX1D