### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# macroquad/miniquad imports its GL and JS glue (glBindTexture, console_log,
+# …) as undefined wasm symbols resolved at load time by mq_js_bundle.js.
+# Rust 1.96 stopped passing --allow-undefined to wasm-ld by default, so those
+# imports now fail to link; pass it back until miniquad annotates them with
+# #[link(wasm_import_module = ...)] upstream. Scoped to the wasm target, so
+# native builds are unaffected.
+# See https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=--allow-undefined"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
@@ -34,3 +35,8 @@ jobs:
 
       - name: Test
         run: cargo test --workspace --locked
+
+      # Guard the web target that pages.yml deploys: without this, a wasm-only
+      # break merges green and only surfaces when the deploy fails on main.
+      - name: Build web (WebAssembly)
+        run: cargo build -p overthrow-app --release --target wasm32-unknown-unknown --locked

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the deploy job to publish to Pages; the token is otherwise read-only.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One live deployment at a time; let an in-flight run finish rather than
+# cancelling it, so a half-published site is never left behind.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build web (WebAssembly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build wasm
+        run: cargo build -p overthrow-app --release --target wasm32-unknown-unknown --locked
+
+      # Serve the committed page shell and JS loader alongside the freshly
+      # built .wasm; the filename must match the load() call in index.html.
+      - name: Assemble site
+        run: |
+          mkdir -p dist
+          cp app/index.html app/mq_js_bundle.js dist/
+          cp target/wasm32-unknown-unknown/release/overthrow-app.wasm dist/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/TODO.md
+++ b/TODO.md
@@ -29,4 +29,14 @@ drawn in the HUD and hit-tested like tiles,
 so every action has a pointer path;
 keep the key bindings as desktop shortcuts.
 
+`.cargo/config.toml` passes `--allow-undefined` to `wasm-ld` so the
+macroquad web build links under Rust 1.96+,
+which stopped importing undefined symbols by default.
+It is a workaround for miniquad not yet annotating its JS/GL imports with
+`#[link(wasm_import_module = ...)]`.
+Next move: once a released miniquad (via `macroquad`) carries those
+annotations, bump the dependency and delete `.cargo/config.toml` —
+the flag masks genuinely missing symbols, so drop it as soon as upstream
+makes it unnecessary.
+
 `Rng::below` in `engine/src/rng.rs` documents "uniform value in `0..bound`" but computes `next_u64() % bound`, which is modulo-biased for bounds that don't divide 2^64 — negligible at the tiny bounds the bot shuffles use, but the doc overpromises. Next move: either soften the doc to say the bias is accepted, or debias (rejection sampling / Lemire); prefer the latter before anything RL-side starts drawing from this RNG, since it would silently skew exploration.

--- a/app/README.md
+++ b/app/README.md
@@ -31,6 +31,10 @@ browsers refuse to fetch `.wasm` from the filesystem.
 (not-fl3.github.io/miniquad-samples);
 re-vendor it from there to update.
 
+The steps above are for local iteration;
+pushes to `main` build this target and publish it to GitHub Pages
+through [`.github/workflows/pages.yml`](../.github/workflows/pages.yml).
+
 ## Android
 
 Packaged with [`cargo-apk`](https://github.com/rust-mobile/cargo-apk),


### PR DESCRIPTION
Set up automated deployment of the WebAssembly app to GitHub Pages on pushes to main.

The workflow builds the `overthrow-app` crate as WebAssembly,
assembles a deployable site from the built `.wasm` artifact and committed shell files,
and deploys to GitHub Pages.
The deployment is serialized to avoid leaving a half-published site.

Key changes:
- Build step compiles the app to `wasm32-unknown-unknown` target in release mode
- Assembly step combines `app/index.html`, `app/mq_js_bundle.js`, and the built `.wasm` into `dist/`
- Deploy step publishes the site using GitHub's native Pages action
- Concurrency settings ensure only one deployment runs at a time

https://claude.ai/code/session_01Ay5dCg8p736DMLRg2DVMe7