### PR TITLE
Replace resource cap with production/maintenance equilibrium

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ rules; split everything else by ownership:
   reference example.
 
 Cross-references go by name: docs name files, types, and functions
-(`engine/src/game.rs`, `Config::growth_divisor`); a code comment whose
+(`engine/src/game.rs`, `Config::maintenance_pct`); a code comment whose
 "why" spans modules points at a `DESIGN.md` section by heading, as the
 `game.rs` module doc does. When renaming a doc heading or a named
 item, grep the other side for references to it.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,11 +21,18 @@ elimination and victory. Map geometry (hexagonal, cube coordinates) is
 `engine/src/coords.rs`. This doc doesn't repeat any of that; it records
 the two cross-cutting intents no single item can show:
 
-- The resource growth curve (`Config::growth_divisor`) is the
-  anti-snowball mechanic at the empire scale: a big empire's tiles sit
-  near the cap and grow slowly, while a recovering player's poor tiles
-  grow quickly — losing ground speeds your economy up instead of
-  ending the game.
+- The resource flow (`Config::production` minus a stockpile-scaled
+  `Config::maintenance_pct`) is the anti-snowball mechanic at the empire
+  scale: a big empire's tiles sit near the equilibrium and grow slowly,
+  while a recovering player's poor tiles grow quickly — losing ground
+  speeds your economy up instead of ending the game. The equilibrium
+  (`Config::resource_equilibrium`) is emergent from two meaningful knobs
+  rather than a hard-cap constant, but this is the same *kind* of curve as
+  the original grow-toward-a-cap rule — tuned leaner — not a new pressure:
+  resources never rise above the equilibrium, so there is no upkeep on a
+  hoard and no bite on passivity. The lever against turtling is army-side
+  (stack decay or garrison upkeep), noted in "Why turtling dominates"
+  below.
 - The command-point pool (`Config::command_points`)
   is the original design's anti-APM currency,
   kept per-army but stripped of accumulation:
@@ -95,20 +102,20 @@ fixed `--seed` so what was seen can be seen again.
 
 ## Observed behavior (bot-vs-bot, radius 5, defaults)
 
-- `greedy` beats `random` 200/200, avg ~89 turns, every win by
-  elimination.
+- `greedy` beats `random` 200/200, avg ~420 turns, about three-quarters by
+  elimination and the rest decided on territory at `max_turns`.
 - Mirror matches are ~50/50 with no first-player advantage — the setup is
   symmetric and turns are truly simultaneous.
 - *Both* mirrors always hit `max_turns` and get decided by tile-count
   adjudication, never elimination. For `random` mirrors the quarter-mark
-  lead barely predicts the winner (comeback rate ~42%) and the lead
-  changes hands constantly (~17 times per game) — noisy play keeps the
-  race open. For `greedy` mirrors it predicted all 186 decided games (0
-  comebacks) and the lead barely moves (~0.7 changes per game over 500
-  turns): under a turtling stalemate whoever grabs the early tile lead
-  holds it to the adjudicated finish. Lead volatility quantifies that
-  turtling — a near-frozen lead over a full game, where the comeback rate
-  only sees the endpoints.
+  lead barely predicts the winner (comeback rate ~35%) and the lead
+  changes hands constantly (~8 times per game) — noisy play keeps the
+  race open. For `greedy` mirrors it nearly always predicts the winner (a
+  handful of comebacks over ~190 decided games) and the lead barely moves
+  (~1.6 changes per game over 500 turns): under a turtling stalemate
+  whoever grabs the early tile lead holds it to the adjudicated finish.
+  Lead volatility quantifies that turtling — a near-frozen lead over a
+  full game, where the comeback rate only sees the endpoints.
   Why the freeze is structural rather than a bot limitation —
   and the levers against it —
   is the subject of "Why turtling dominates" below.

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -36,13 +36,30 @@ pub struct Config {
     pub initial_army: u32,
     /// Resources every tile starts with.
     pub initial_resources: u32,
-    /// Resources stop growing at this value.
-    pub resource_cap: u32,
-    /// Per-turn growth is `max(1, (resource_cap - resources) / growth_divisor)`:
-    /// fast when low, slow near the cap — the anti-snowball curve.
-    pub growth_divisor: u32,
+    /// Flat resources every tile produces each turn — the production half of
+    /// the production/maintenance flow (see `maintenance_pct`).
+    pub production: u32,
+    /// Per-turn maintenance each tile pays,
+    /// as a percent of the resources present (`2` = 2% of the stockpile).
+    /// Production minus this maintenance is a self-limiting flow:
+    /// a poor tile grows fast and a near-full one barely grows
+    /// — the anti-snowball curve —
+    /// settling at the emergent cap `Config::resource_equilibrium`.
+    /// A percentage, so it must be in `1..=100`.
+    pub maintenance_pct: u32,
     /// Defender strength multiplier in percent (125 = 1.25x).
     pub defense_bonus_pct: u32,
+}
+
+impl Config {
+    /// The resource level a tile converges to under the production/maintenance
+    /// flow: `ceil(production * 100 / maintenance_pct)`. There maintenance
+    /// cancels production and growth stops — the emergent cap, in place of a
+    /// hard constant. Growing from below (as every tile does from
+    /// `initial_resources`), a tile lands on exactly this value.
+    pub fn resource_equilibrium(&self) -> u32 {
+        (self.production * 100).div_ceil(self.maintenance_pct)
+    }
 }
 
 impl Default for Config {
@@ -54,8 +71,8 @@ impl Default for Config {
             max_turns: 500,
             initial_army: 20,
             initial_resources: 10,
-            resource_cap: 100,
-            growth_divisor: 25,
+            production: 2,
+            maintenance_pct: 2,
             defense_bonus_pct: 125,
         }
     }
@@ -133,7 +150,10 @@ impl GameState {
             "2 to 6 players supported (one corner each)"
         );
         assert!(config.radius >= 1, "map too small");
-        assert!(config.growth_divisor >= 1, "growth_divisor must be nonzero");
+        assert!(
+            (1..=100).contains(&config.maintenance_pct),
+            "maintenance_pct is a percentage in 1..=100"
+        );
 
         let hexes: Vec<Hex> = hexagon(config.radius).collect();
         let index: HashMap<Hex, usize> = hexes.iter().enumerate().map(|(i, h)| (*h, i)).collect();
@@ -330,7 +350,8 @@ impl GameState {
     ///
     /// Each player's orders apply to their own tiles only, so the player
     /// processing order is irrelevant: departures and recruits happen
-    /// "at once", then everything lands and fights, then resources grow.
+    /// "at once", then everything lands and fights, then resources flow
+    /// (production minus maintenance).
     /// One order per tile per turn also means recruited armies defend
     /// immediately but cannot move until the next turn.
     pub fn step(&mut self, orders: &[Vec<Order>]) -> Outcome {
@@ -441,14 +462,13 @@ impl GameState {
             tile.army = surviving.min(u32::MAX as u128) as u32;
         }
 
-        // Resource growth on every tile: fast when poor, slow near the cap.
+        // Flat production minus stockpile-scaled maintenance; converges up to
+        // `Config::resource_equilibrium`. `maintenance_pct <= 100` keeps the
+        // maintenance from exceeding the stockpile, so the subtraction is safe.
         for tile in &mut self.tiles {
-            if tile.resources < self.config.resource_cap {
-                let growth = ((self.config.resource_cap - tile.resources)
-                    / self.config.growth_divisor)
-                    .max(1);
-                tile.resources = (tile.resources + growth).min(self.config.resource_cap);
-            }
+            let maintenance =
+                (tile.resources as u64 * self.config.maintenance_pct as u64 / 100) as u32;
+            tile.resources = (tile.resources - maintenance).saturating_add(self.config.production);
         }
 
         self.turn += 1;
@@ -752,15 +772,14 @@ mod tests {
     }
 
     #[test]
-    fn resources_grow_toward_cap() {
+    fn resources_converge_to_equilibrium() {
         let mut s = state();
-        for _ in 0..2000 {
+        // Far more turns than the ~100 a tile needs to climb from
+        // `initial_resources` to the equilibrium and stop there.
+        for _ in 0..s.config.max_turns {
             s.step(&[vec![], vec![]]);
-            if s.turn >= s.config.max_turns {
-                break;
-            }
         }
-        let cap = s.config.resource_cap;
-        assert!(s.iter_tiles().all(|(_, t)| t.resources == cap));
+        let eq = s.config.resource_equilibrium();
+        assert!(s.iter_tiles().all(|(_, t)| t.resources == eq));
     }
 }

--- a/engine/tests/invariants.rs
+++ b/engine/tests/invariants.rs
@@ -90,9 +90,12 @@ fn check_invariants(state: &GameState, ever_owned: &mut HashSet<Hex>) {
                 ever_owned.insert(hex);
             }
         }
+        // Resources grow up to the production/maintenance equilibrium and
+        // stop; nothing raises them past it (recruit only lowers them), so
+        // it is a hard ceiling.
         assert!(
-            tile.resources <= state.config.resource_cap,
-            "tile {hex:?} exceeds the resource cap"
+            tile.resources <= state.config.resource_equilibrium(),
+            "tile {hex:?} exceeds its resource equilibrium"
         );
     }
     assert!(
@@ -177,4 +180,4 @@ fn golden_game_final_state_is_pinned() {
 }
 
 const GOLDEN_TURNS: u32 = 200;
-const GOLDEN_HASH: u64 = 10135845784850105762;
+const GOLDEN_HASH: u64 = 1061877323026431320;


### PR DESCRIPTION
Replace the hard resource cap and divisor-based growth curve with a production/maintenance flow model that converges to an emergent equilibrium.

## Summary

This refactors the resource economy from a growth-toward-cap model to a production-minus-maintenance model.
The new system is more tunable (two meaningful knobs instead of one) and produces the same anti-snowball behavior through an emergent equilibrium rather than a hard constant.

## Key changes

- Replace `Config::resource_cap` and `Config::growth_divisor` with `Config::production` (flat per-turn output) and `Config::maintenance_pct` (stockpile-scaled cost as a percentage).
- Add `Config::resource_equilibrium()` method that computes the emergent cap as `ceil(production * 100 / maintenance_pct)`.
- Update resource flow logic: each turn, tiles now pay maintenance (a percentage of their stockpile) and gain production, converging to equilibrium rather than capping at a constant.
- Update validation to ensure `maintenance_pct` is in the valid range `1..=100`.
- Update test expectations and invariant checks to use the new equilibrium model.
- Update `DESIGN.md` to document the new model and reflect observed behavior changes (games now run longer, ~420 turns vs ~89 with the old curve).

## Implementation details

The maintenance calculation uses integer arithmetic with saturation to avoid underflow:
`tile.resources = (tile.resources - maintenance).saturating_add(production)`.
The constraint `maintenance_pct <= 100` ensures maintenance never exceeds the stockpile, making the subtraction safe.
The equilibrium is a hard ceiling (nothing raises resources past it except the flow itself), preserving the anti-snowball property.

https://claude.ai/code/session_01ET84fWUhzHrzoHcznmYuhM