### PR TITLE
Add TacticianBot: a stronger scripted heuristic that beats GreedyBot

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -104,6 +104,22 @@ fixed `--seed` so what was seen can be seen again.
 
 - `greedy` beats `random` 200/200, avg ~420 turns, about three-quarters by
   elimination and the rest decided on territory at `max_turns`.
+- `tactician` beats `greedy` from either seat — 200/200 at radius 5, and a
+  clean sweep at every radius tested from 4 up (4, 6, 7) — but never by
+  elimination: like the `greedy` mirror, every game runs to `max_turns` and
+  is decided on tile count. It wins the opening land grab (claiming toward
+  the contested centre with pool-efficient moves, holding the frontier with
+  garrisons the capped attacker cannot out-fund) and freezes ahead, rather
+  than trading armies into the defense bonus. So the `greedy`-mirror freeze
+  was partly a `greedy` limitation — a better land-grabber simply owns more
+  of the board when the lead locks in — not purely structural; `tactician`
+  still cannot break `greedy`'s turtle, only out-turtle it (see "Why
+  turtling dominates" below). Its own mirror keeps a mild first-seat lean
+  (~55/45 over 400 games, where `greedy`'s is even); the likeliest cause is
+  combat's tie-break — `GameState::step` awards an exact-strength clash to
+  the lower player id — which its centre-axis march runs into more often
+  than `greedy`'s looser expansion, but that is unverified analysis, not a
+  measured decomposition.
 - Mirror matches are ~50/50 with no first-player advantage — the setup is
   symmetric and turns are truly simultaneous.
 - *Both* mirrors always hit `max_turns` and get decided by tile-count
@@ -165,6 +181,11 @@ and it has a cheap falsification test:
 a scripted turtle-breaker bot
 (stage stacks, converge on the thinnest border tile);
 if it can beat `greedy`, the argument is wrong.
+`tactician` beating `greedy` is not that falsification:
+it wins the tile-count adjudication by out-grabbing the neutral land
+and never by breaking a garrison,
+so its sweep is over-turtling, not offense out-delivering defense —
+the leg the test targets still stands.
 
 Each candidate anti-turtling lever attacks one leg:
 stack decay or upkeep bounds defense;

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ preserved under [`old/`](old/) as a reference implementation.
 - `engine/` — pure game rules. Deterministic, no I/O, no dependencies.
   The single source of truth, intended to be reused unchanged by the
   desktop/Android app, headless simulation, and RL training.
-- `bot/` — opponents implementing the `Bot` trait: `random` (baseline) and
-  `greedy` (scripted heuristic). A learned policy bot will slot in here.
+- `bot/` — opponents implementing the `Bot` trait: `random` (baseline),
+  `greedy` (scripted heuristic) and `tactician` (a stronger heuristic that
+  beats `greedy`). A learned policy bot will slot in here.
 - `cli/` — headless runner for bot-vs-bot matches.
 - `app/` — playable [macroquad](https://macroquad.rs) frontend
   (human vs bot, or spectating a bot-vs-bot match).
@@ -34,7 +35,7 @@ preserved under [`old/`](old/) as a reference implementation.
     cargo test
     cargo run --release -p overthrow-cli -- match --games 200
     cargo run --release -p overthrow-cli -- match --games 1 --render
-    cargo run --release -p overthrow-cli -- match --bots greedy,greedy --radius 6
+    cargo run --release -p overthrow-cli -- match --bots tactician,greedy --radius 6
     cargo run --release -p overthrow-cli -- match --bots greedy,greedy,greedy,greedy,greedy,greedy --radius 6
 
 ## Roadmap

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Belongs here: refactors, dead code, inconsistencies, missing tests, sketchy patt
 
 `cli/src/main.rs` handles bad flag values inconsistently: a non-numeric `--games`, `--radius`, or `--seed` panics through `expect` (a raw Rust panic message with a backtrace hint), while every other user error in the same parser — missing value, unknown flag, malformed `--bots` — prints a one-line message and exits with code 2. Next move: replace the three `expect` calls with the `eprintln!` + `exit(2)` shape their neighbors already use, and pin the exit code with a case in `cli/tests/cli.rs` alongside `unknown_arguments_are_rejected`.
 
-The bot-name list lives in three places: `make_bot` in `bot/src/lib.rs` is the actual registry, and `cli/src/main.rs` repeats it twice as prose — the module doc's "Bots: greedy, random." and the unknown-bot error's "(available: greedy, random)". The usage line is likewise written out twice (module doc and the `eprintln!`). Adding a bot updates one match arm and silently strands the strings. Next move: export a name list next to `make_bot` (e.g. `pub const BOT_NAMES: &[&str]`), build the CLI error message from it, and have the doc comments point at `make_bot` instead of enumerating.
+The CLI usage line is written out twice in `cli/src/main.rs` — the module doc and the `eprintln!` on a bad subcommand — so a flag added to one can drift from the other. Next move: hoist the string to a `const USAGE: &str` and print that in both places (or have the module doc point at it rather than restate it).
 
 `app/` is keyboard-and-mouse only:
 every non-map action is a key press —
@@ -49,12 +49,14 @@ so an attack scored as winning can land under-strength and lose —
 greedy throws armies and CP at overruns it can't actually fund this turn.
 The scoring pass is blind to the pool because `take_budget` allocates CP
 only afterwards.
-Next move: fold the pool into scoring —
-walk candidates in priority order tracking remaining CP,
-and only commit an attack whose funded strength (`min(army, remaining)`)
-still clears `needed`, deferring or downgrading the rest.
-Behavior change (greedy plays differently), so it needs sign-off and a
-fresh `bot/tests/health.rs` check.
+Next move: give greedy's attacks a funding floor —
+`take_budget_floored` (added for `TacticianBot`)
+already drops an order whose `min(army, remaining)` share
+falls below a per-order `min_useful`,
+so greedy need only tag each attack candidate with `needed`
+and route through it, exactly as `TacticianBot` does.
+Behavior change (greedy plays differently),
+so it needs sign-off and a fresh `bot/tests/health.rs` check.
 
 `Rng::below` in `engine/src/rng.rs` documents "uniform value in `0..bound`" but computes `next_u64() % bound`, which is modulo-biased for bounds that don't divide 2^64 — negligible at the tiny bounds the bot shuffles use, but the doc overpromises. Next move: either soften the doc to say the bias is accepted, or debias (rejection sampling / Lemire); prefer the latter before anything RL-side starts drawing from this RNG, since it would silently skew exploration.
 

--- a/bot/src/lib.rs
+++ b/bot/src/lib.rs
@@ -1,8 +1,12 @@
 //! Bots: strategies that map a game state to a set of orders.
 //!
-//! `RandomBot` is the sanity baseline; `GreedyBot` is a scripted heuristic
-//! opponent. A learned (neural-network) bot will implement the same `Bot`
-//! trait later, so everything that can run these two can run it.
+//! `RandomBot` is the sanity baseline,
+//! `GreedyBot` a scripted heuristic,
+//! and `TacticianBot` a stronger heuristic that beats it.
+//! A learned (neural-network) bot will implement the same `Bot` trait later,
+//! so everything that can run these can run it.
+//! `make_bot` is the name registry,
+//! and `BOT_NAMES` lists every name it accepts.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -10,8 +14,10 @@ use overthrow_engine::rng::Rng;
 use overthrow_engine::{Config, GameState, Hex, MoveAmount, Order, Outcome, PlayerId};
 
 pub mod stats;
+pub mod tactician;
 
 pub use stats::{MatchRecord, SeriesStats};
+pub use tactician::TacticianBot;
 
 pub trait Bot {
     fn name(&self) -> &'static str;
@@ -50,10 +56,27 @@ pub fn run_match(config: Config, bots: &mut [Box<dyn Bot>]) -> (GameState, Match
 /// (the last order kept may only be partly paid,
 /// exactly as the engine runs it partially).
 fn take_budget(state: &GameState, candidates: impl IntoIterator<Item = Order>) -> Vec<Order> {
+    take_budget_floored(state, candidates.into_iter().map(|order| (order, 1)))
+}
+
+/// `take_budget` with a per-order floor.
+/// `min_useful` is the fewest armies an order must actually be funded for
+/// to be worth keeping:
+/// the pool clamps a move or recruit to `min(cost, remaining)`,
+/// and an order that would land below its floor is skipped
+/// rather than committed under-strength —
+/// the leverage a bot needs to refuse an attack that loses beneath `needed`
+/// instead of bleeding army into it.
+/// A floor of `1` (anything the pool pays for is progress)
+/// recovers plain `take_budget`.
+pub(crate) fn take_budget_floored(
+    state: &GameState,
+    candidates: impl IntoIterator<Item = (Order, u32)>,
+) -> Vec<Order> {
     let mut used_sources = HashSet::new();
     let mut remaining = state.config.command_points;
     let mut chosen = Vec::new();
-    for order in candidates {
+    for (order, min_useful) in candidates {
         if remaining == 0 {
             break;
         }
@@ -64,11 +87,40 @@ fn take_budget(state: &GameState, candidates: impl IntoIterator<Item = Order>) -
         if cost == 0 {
             continue;
         }
+        let funded = cost.min(remaining);
+        if funded < min_useful {
+            continue;
+        }
         used_sources.insert(order.source());
         chosen.push(order);
-        remaining = remaining.saturating_sub(cost);
+        remaining -= funded;
     }
     chosen
+}
+
+/// BFS distance from every tile to the nearest tile not owned by `me`.
+/// One O(tiles) pass per turn;
+/// interior armies descend this gradient toward the fighting.
+/// Shared by the scripted bots that route reserves forward.
+pub(crate) fn frontier_distances(state: &GameState, me: PlayerId) -> HashMap<Hex, u32> {
+    let mut dist = HashMap::new();
+    let mut queue = VecDeque::new();
+    for (hex, tile) in state.iter_tiles() {
+        if tile.owner != Some(me) {
+            dist.insert(hex, 0);
+            queue.push_back(hex);
+        }
+    }
+    while let Some(hex) = queue.pop_front() {
+        let d = dist[&hex];
+        for (_, neighbor) in hex.neighbors() {
+            if state.tile(neighbor).is_some() && !dist.contains_key(&neighbor) {
+                dist.insert(neighbor, d + 1);
+                queue.push_back(neighbor);
+            }
+        }
+    }
+    dist
 }
 
 /// Picks uniformly random legal orders (one per source tile).
@@ -109,29 +161,6 @@ impl GreedyBot {
             rng: Rng::new(seed),
         }
     }
-
-    /// BFS distance from every tile to the nearest tile not owned by `me`.
-    /// One O(tiles) pass per turn; interior armies descend this gradient.
-    fn frontier_distances(state: &GameState, me: PlayerId) -> HashMap<Hex, u32> {
-        let mut dist = HashMap::new();
-        let mut queue = VecDeque::new();
-        for (hex, tile) in state.iter_tiles() {
-            if tile.owner != Some(me) {
-                dist.insert(hex, 0);
-                queue.push_back(hex);
-            }
-        }
-        while let Some(hex) = queue.pop_front() {
-            let d = dist[&hex];
-            for (_, neighbor) in hex.neighbors() {
-                if state.tile(neighbor).is_some() && !dist.contains_key(&neighbor) {
-                    dist.insert(neighbor, d + 1);
-                    queue.push_back(neighbor);
-                }
-            }
-        }
-        dist
-    }
 }
 
 impl Bot for GreedyBot {
@@ -140,7 +169,7 @@ impl Bot for GreedyBot {
     }
 
     fn orders(&mut self, state: &GameState, me: PlayerId) -> Vec<Order> {
-        let frontier = Self::frontier_distances(state, me);
+        let frontier = frontier_distances(state, me);
         // (priority, order); higher priority first.
         let mut scored: Vec<(i64, Order)> = Vec::new();
 
@@ -245,10 +274,15 @@ impl Bot for GreedyBot {
     }
 }
 
+/// Every name `make_bot` accepts, for CLI usage and error strings so the
+/// list is written once. Keep in sync with `make_bot`'s match arms.
+pub const BOT_NAMES: &[&str] = &["random", "greedy", "tactician"];
+
 pub fn make_bot(name: &str, seed: u64) -> Option<Box<dyn Bot>> {
     match name {
         "random" => Some(Box::new(RandomBot::new(seed))),
         "greedy" => Some(Box::new(GreedyBot::new(seed))),
+        "tactician" => Some(Box::new(TacticianBot::new(seed))),
         _ => None,
     }
 }

--- a/bot/src/tactician.rs
+++ b/bot/src/tactician.rs
@@ -1,0 +1,206 @@
+//! `TacticianBot`: a scripted heuristic that beats `GreedyBot`.
+//!
+//! Under the v1 rules a careful player wins the two-player game
+//! without ever breaking a defense:
+//! games are decided on tile count at `Config::max_turns`,
+//! and a frontier garrison the command-point-capped attacker cannot
+//! out-fund holds indefinitely
+//! (why this favours the defender: `DESIGN.md`, "Why turtling dominates";
+//! the combat that makes a held tile stick is `GameState::step`).
+//! So the tactician wins the neutral land grab and holds it,
+//! instead of trading armies into the defense bonus like `GreedyBot`.
+//!
+//! Three things distinguish it from `GreedyBot`:
+//!
+//! - Command-point-aware funding (`crate::take_budget_floored`):
+//!   an attack is kept only when the pool will actually pay for a force
+//!   that still beats the defender,
+//!   never the under-funded overrun `GreedyBot` throws away.
+//! - It claims neutral tiles toward the map centre first
+//!   — the ground both players race for —
+//!   to own more than half the board before contact.
+//! - It garrisons only threatened tiles,
+//!   and only to what survives one maximal enemy turn,
+//!   spending the rest of the pool on expansion rather than over-recruiting.
+
+use overthrow_engine::rng::Rng;
+use overthrow_engine::{GameState, Hex, MoveAmount, Order, PlayerId};
+
+use crate::{frontier_distances, take_budget_floored, Bot};
+
+/// A scored candidate order.
+/// `min_useful` is the smallest number of armies
+/// the order must actually move or raise to be worth issuing —
+/// `needed` for an attack (below it the attack loses and only bleeds army),
+/// `1` otherwise — which the funding pass enforces.
+struct Candidate {
+    priority: i64,
+    order: Order,
+    min_useful: u32,
+}
+
+pub struct TacticianBot {
+    rng: Rng,
+}
+
+impl TacticianBot {
+    pub fn new(seed: u64) -> Self {
+        TacticianBot {
+            rng: Rng::new(seed),
+        }
+    }
+
+    /// The most army an enemy could land on `hex` in one turn:
+    /// the sum of enemy armies on adjacent enemy tiles,
+    /// capped by the command-point pool
+    /// (no player ships more than the pool a turn).
+    /// An over-estimate on the funnelling side
+    /// and an under-estimate against several enemies at once,
+    /// but a safe garrison target for the two-player duel the ML plan targets.
+    fn incoming_threat(state: &GameState, me: PlayerId, hex: Hex) -> u64 {
+        let adjacent: u64 = hex
+            .neighbors()
+            .filter_map(|(_, n)| state.tile(n))
+            .filter(|t| t.owner.is_some_and(|o| o != me))
+            .map(|t| t.army as u64)
+            .sum();
+        adjacent.min(state.config.command_points as u64)
+    }
+
+    /// The garrison that survives `threat` incoming armies with a unit to
+    /// spare: the smallest `g` with `g * defense_bonus_pct / 100 > threat`.
+    /// A tile held this strongly keeps both its ownership
+    /// and a defending army through one maximal enemy turn.
+    fn garrison_to_hold(state: &GameState, threat: u64) -> u64 {
+        let bonus = state.config.defense_bonus_pct as u64;
+        // Smallest g with g*bonus/100 > threat  <=>  g*bonus > threat*100.
+        (threat * 100) / bonus + 1
+    }
+}
+
+impl Bot for TacticianBot {
+    fn name(&self) -> &'static str {
+        "tactician"
+    }
+
+    fn orders(&mut self, state: &GameState, me: PlayerId) -> Vec<Order> {
+        let frontier = frontier_distances(state, me);
+        let bonus = state.config.defense_bonus_pct as i64;
+        let radius = state.config.radius;
+        let center = Hex::new(0, 0);
+        let mut candidates: Vec<Candidate> = Vec::new();
+
+        for (hex, tile) in state.iter_tiles() {
+            if tile.owner != Some(me) {
+                continue;
+            }
+
+            let threat = Self::incoming_threat(state, me, hex);
+            let threatened = threat > 0;
+
+            // Reinforce a threatened tile up to a garrison that survives the
+            // worst incoming turn, by converting its own resources; the more
+            // exposed the tile, the earlier it is funded.
+            if threatened
+                && tile.resources > 0
+                && (tile.army as u64) < Self::garrison_to_hold(state, threat)
+            {
+                candidates.push(Candidate {
+                    priority: 1000 + threat as i64,
+                    order: Order::Recruit { at: hex },
+                    min_useful: 1,
+                });
+            }
+
+            if tile.army == 0 {
+                continue;
+            }
+
+            let mut acted = false;
+            for (dir, next_hex) in hex.neighbors() {
+                let Some(next) = state.tile(next_hex) else {
+                    continue;
+                };
+                match next.owner {
+                    // Neutral tile: claim it. Race toward the centre (the
+                    // contested ground) and prefer rich tiles. Send half of a
+                    // stack so the source keeps a footing, all of a lone
+                    // pioneer so it keeps advancing.
+                    None => {
+                        let toward_center = (radius - next_hex.distance(center)) as i64;
+                        let amount = if tile.army >= 2 {
+                            MoveAmount::Half
+                        } else {
+                            MoveAmount::All
+                        };
+                        candidates.push(Candidate {
+                            priority: 400 + 4 * toward_center + next.resources as i64,
+                            order: Order::Move {
+                                from: hex,
+                                dir,
+                                amount,
+                            },
+                            min_useful: 1,
+                        });
+                        acted = true;
+                    }
+                    // Enemy tile: rank a capture (a two-tile swing) by how
+                    // cheap the kill is. The `needed` floor is what makes the
+                    // attack safe — the funding pass drops it unless the pool
+                    // pays for a force that strictly beats the bonus-scaled
+                    // defender, so an under-funded attack is never issued.
+                    Some(owner) if owner != me => {
+                        let needed = (next.army as i64 * bonus) / 100 + 1;
+                        if (tile.army as i64) >= needed {
+                            candidates.push(Candidate {
+                                priority: 800 - needed,
+                                order: Order::Move {
+                                    from: hex,
+                                    dir,
+                                    amount: MoveAmount::All,
+                                },
+                                min_useful: needed as u32,
+                            });
+                            acted = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Idle interior army: walk it toward the frontier so force reaches
+            // the contested edge instead of sitting in the rear. Emit one
+            // candidate per direction that strictly descends the frontier
+            // gradient and let the pre-sort shuffle break ties — a
+            // deterministic pick would bake a fixed compass direction into the
+            // play and hand one seat the centre.
+            if !acted && !threatened && tile.army >= 2 {
+                let here = frontier.get(&hex).copied().unwrap_or(0);
+                for (dir, next_hex) in hex.neighbors() {
+                    let owned = state.tile(next_hex).is_some_and(|t| t.owner == Some(me));
+                    let closer = frontier.get(&next_hex).copied().unwrap_or(u32::MAX) < here;
+                    if owned && closer {
+                        candidates.push(Candidate {
+                            priority: 200 + tile.army as i64,
+                            order: Order::Move {
+                                from: hex,
+                                dir,
+                                amount: MoveAmount::All,
+                            },
+                            min_useful: 1,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Shuffle before the stable sort so equal-priority orders don't always
+        // resolve in map order, then fund in priority order.
+        self.rng.shuffle(&mut candidates);
+        candidates.sort_by_key(|c| std::cmp::Reverse(c.priority));
+        take_budget_floored(
+            state,
+            candidates.into_iter().map(|c| (c.order, c.min_useful)),
+        )
+    }
+}

--- a/bot/tests/health.rs
+++ b/bot/tests/health.rs
@@ -53,6 +53,24 @@ fn greedy_dominates_random_by_elimination() {
     );
 }
 
+/// The scripted ladder must have a top rung:
+/// `tactician` beats `greedy` decisively from either seat.
+/// It wins the neutral land grab and holds it to the tile-count adjudication
+/// rather than trading into the defense bonus,
+/// so — like every `greedy` mirror — these games run to the turn limit;
+/// the win shows up in the standings, not in eliminations.
+/// Guards against a change that lets `greedy`
+/// (or the shared funding/expansion code) regress the stronger bot.
+#[test]
+fn tactician_dominates_greedy_from_either_seat() {
+    let as_p0 = run_series(("tactician", "greedy"), 20).wins_of(PlayerId(0));
+    let as_p1 = run_series(("greedy", "tactician"), 20).wins_of(PlayerId(1));
+    assert!(
+        as_p0 >= 18 && as_p1 >= 18,
+        "tactician should dominate greedy from either seat, won {as_p0}/20 as P0, {as_p1}/20 as P1"
+    );
+}
+
 /// Fairness: strength must not depend on seat order. The setup is
 /// symmetric and turns resolve simultaneously, so greedy must dominate
 /// random equally as P0 and as P1.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,12 +4,13 @@
 //!   overthrow match [--games N] [--radius R] [--bots A,B,...] [--seed S] [--render]
 //!
 //! `--bots` takes 2 to 6 comma-separated names, one per player; the player
-//! count follows from the list. Bots: greedy, random.
+//! count follows from the list. The accepted names are `overthrow_bot`'s
+//! `make_bot` registry, listed in `BOT_NAMES`.
 
 use std::env;
 use std::process::exit;
 
-use overthrow_bot::{make_bot, run_match, Bot, SeriesStats};
+use overthrow_bot::{make_bot, run_match, Bot, SeriesStats, BOT_NAMES};
 use overthrow_engine::{Config, GameState, Hex, PlayerId};
 
 fn main() {
@@ -75,7 +76,7 @@ fn main() {
             .map(|(i, name)| {
                 make_bot(name, game_seed.wrapping_mul(2).wrapping_add(i as u64)).unwrap_or_else(
                     || {
-                        eprintln!("unknown bot: {name} (available: greedy, random)");
+                        eprintln!("unknown bot: {name} (available: {})", BOT_NAMES.join(", "));
                         exit(2);
                     },
                 )


### PR DESCRIPTION
Introduces `TacticianBot`, a new scripted bot strategy that beats `GreedyBot` decisively from either seat by winning the neutral land grab and holding it to the tile-count adjudication, rather than trading armies into the defense bonus.

## Key changes

- **New `TacticianBot` implementation** (`bot/src/tactician.rs`):
  - Claims neutral tiles toward the map centre first (the contested ground both players race for) to own more than half the board before contact
  - Uses command-point-aware funding via `take_budget_floored` to keep only attacks the pool can actually fund to victory
  - Garrisons only threatened tiles, and only to what survives one maximal enemy turn, spending the rest on expansion
  - Includes helper methods `incoming_threat` (estimates max army an enemy could land in one turn) and `garrison_to_hold` (calculates garrison needed to survive that threat)

- **Refactored shared utilities** (`bot/src/lib.rs`):
  - Extracted `frontier_distances` from `GreedyBot` to a module-level function so both scripted bots can route reserves forward
  - Introduced `take_budget_floored` with per-order minimum-useful thresholds, allowing bots to refuse under-funded attacks that would lose beneath a required strength
  - Plain `take_budget` now delegates to `take_budget_floored` with a floor of 1
  - Updated `make_bot` registry and added `BOT_NAMES` constant for CLI usage

- **Test coverage** (`bot/tests/health.rs`):
  - Added `tactician_dominates_greedy_from_either_seat` test ensuring the new bot wins decisively (≥18/20) from both player positions

- **Documentation updates**:
  - Updated `DESIGN.md` with empirical results: `tactician` beats `greedy` 200/200 at radius 5 and sweeps every radius tested (4, 6, 7), always running to `max_turns` and winning on tile count
  - Clarified that `tactician`'s sweep is over-turtling (out-grabbing neutral land), not breaking the defense, so the turtle-dominance argument still stands
  - Updated `README.md` and `cli/src/main.rs` to list `tactician` as an available bot
  - Updated `TODO.md` to reflect that the bot-name list is now centralized in `BOT_NAMES`

## Implementation notes

The bot's three key distinctions from `GreedyBot`:
1. **Command-point-aware funding**: attacks are kept only when the pool will actually pay for a force that beats the defender, never the under-funded overruns `GreedyBot` throws away
2. **Centre-first expansion**: claims neutral tiles toward the map centre to own more than half the board before contact
3. **Efficient garrisons**: reinforces only threatened tiles to the minimum needed to survive one maximal enemy turn, spending the rest on expansion rather than over-recruiting

The bot uses a candidate-scoring system with priorities (1000+ for reinforcement, 800 for attacks, 400 for neutral claims, 200 for frontier movement) and enforces minimum-useful thresholds per order to prevent under-funded commitments.

https://claude.ai/code/session_01KzAmyE2mkB9GBQWpapDVEJ