### PR TITLE
Remove defense bonus; garrison now strikes for nothing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,7 +50,7 @@ the two cross-cutting intents no single item can show:
 |---|---|---|
 | Move order targets any tile, engine paths one hex/turn | Move targets an adjacent tile only | Long moves are UI sugar over the same mechanic; per-step orders shrink the ML action space to `tiles × 6 × 2 + recruit` per order slot (passing = submitting fewer orders; there is no explicit pass order) |
 | Command points: earned, spent per army per step, accumulated to a cap | Per-army `command_points` pool spent per step, no accumulation | Kept the per-army cost — it makes force projection the scarce resource and offensives staged rather than free. Dropped only accumulation, which existed to let idle players catch up — irrelevant for local/AI games (decision, 2026-07) |
-| Multi-turn attrition combat with attack/defense efficiency constants | Single-step strongest-party-wins with defense bonus | Fewer states in flight, no movement records to track, easier credit assignment for RL. Attrition combat can return if fights feel too binary |
+| Multi-turn attrition combat with attack/defense efficiency constants | Single step, no defense — only mutual attack: a stationary garrison deals no damage, so a winning attacker keeps its full force | Fewer states in flight, no movement records to track, easier credit assignment for RL. A garrison is presence you must out-deliver, not an army that fights back; the defender bonus that shipped in early v1 went with it (see "Why turtling dominates") |
 | Real-time ticks, no end | Discrete turns, `max_turns` limit, tile-count victory | RL needs episodes; a single-player game needs an ending |
 | Corporations, boss trees, transfers | Omitted | Out of scope for single-player vs AI (deliberate decision, 2026-07) |
 | Army cap tied to CP cap | No cap | Keep constants minimal; revisit if unbounded stacks distort play |
@@ -110,7 +110,7 @@ fixed `--seed` so what was seen can be seen again.
   is decided on tile count. It wins the opening land grab (claiming toward
   the contested centre with pool-efficient moves, holding the frontier with
   garrisons the capped attacker cannot out-fund) and freezes ahead, rather
-  than trading armies into the defense bonus. So the `greedy`-mirror freeze
+  than trading armies into a full-strength garrison. So the `greedy`-mirror freeze
   was partly a `greedy` limitation — a better land-grabber simply owns more
   of the board when the lead locks in — not purely structural; `tactician`
   still cannot break `greedy`'s turtle, only out-turtle it (see "Why
@@ -170,19 +170,25 @@ so a stronger opponent (including a learned one)
 would turtle harder, not break the stalemate.
 Three legs:
 
-- Offense is capped, defense is not.
+- Offense is capped, presence is not.
   The command-point pool is charged per army moved,
   out of one shared per-turn pool,
-  so a player projects at most `Config::command_points` armies per turn
+  so a player delivers at most `Config::command_points` armies
+  to any one tile in a turn
   no matter how long they stage,
-  while a garrison persists indefinitely
-  and defends at full size times `Config::defense_bonus_pct`.
-  A garrison of the pool divided by the bonus (16 at defaults)
-  already forces at best mutual annihilation.
-- Every attack into defense trades at the bonus exchange rate,
-  and both sides convert the same per-turn pool into board effect
-  (raising or moving),
-  so an attacker can never out-produce the losses.
+  while a garrison persists indefinitely.
+  Taking a tile means out-presenting its garrison in a single turn,
+  so a garrison matching the pool (20 at defaults) cannot be taken:
+  the most an attack can muster only matches it, which annihilates.
+- Cheaper offense does not obviously help.
+  A won attack keeps the attacker's full force —
+  the garrison strikes for nothing —
+  so offense costs less than it did under attrition,
+  yet no single turn can still deliver past a pool-sized garrison,
+  and whittling one down trades even
+  while the defender re-recruits from its own equal pool.
+  Both sides convert the same per-turn pool into board effect,
+  so neither out-delivers the other's regeneration.
 - Passivity is free and wins:
   resources grow whether or not a player acts,
   stacks never decay,
@@ -197,7 +203,7 @@ if it can beat `greedy`, the argument is wrong.
 `tactician` beating `greedy` is not that falsification:
 it wins the tile-count adjudication by out-grabbing the neutral land
 and never by breaking a garrison,
-so its sweep is over-turtling, not offense out-delivering defense —
+so its sweep is over-turtling, not an attack out-delivering a garrison —
 the leg the test targets still stands.
 
 Each candidate anti-turtling lever attacks one leg:
@@ -210,6 +216,30 @@ implement the levers as `Config` knobs,
 run the gameplay-health metrics per variant,
 and keep the one lever that restores elimination and comebacks —
 one, because every surviving constant must earn its place.
+
+Decision (2026-07-14): removed the notion of defense entirely.
+A stationary garrison used to fight back for free —
+the "auto-defense" that made holding cost the attacker armies —
+and carried a 1.25x bonus (`defense_bonus_pct`) on top;
+both are gone.
+A garrison now strikes for nothing
+(to inflict losses an army must be commanded to move),
+and the bonus had no meaning once there is no defense to scale.
+
+Whether this loosens the turtle is still open.
+The headline matchups are unmoved —
+`greedy` still beats `random` about three-quarters by elimination
+(avg ~420 turns) and `tactician` still freezes `greedy`
+to the turn limit — but that is weak evidence:
+`greedy` and `tactician` were shaped under the old rules
+and never attack a garrison they cannot overrun in one turn,
+so neither tests whether cheaper offense now pays.
+The structural reason to expect the freeze to survive is unchanged
+(the per-turn pool caps delivery to any one tile,
+so a pool-sized garrison still cannot be taken in a turn),
+but the clean check is the turtle-breaker bot proposed above,
+which has not been run.
+The offense cap and free passivity remain the legs to target.
 
 In principle more players weakens the first leg:
 the offense cap is per player,

--- a/bot/src/lib.rs
+++ b/bot/src/lib.rs
@@ -225,11 +225,10 @@ impl Bot for GreedyBot {
                         ));
                         moved_somewhere = true;
                     }
-                    // Enemy tile: attack only with a margin over what the
-                    // configured defense bonus makes the defender worth.
+                    // Enemy tile: attack only with a margin that strictly
+                    // outnumbers the enemy garrison.
                     Some(owner) if owner != me => {
-                        let needed =
-                            (next.army as i64 * state.config.defense_bonus_pct as i64) / 100 + 1;
+                        let needed = next.army as i64 + 1;
                         if (tile.army as i64) >= needed {
                             scored.push((
                                 800 + (tile.army as i64 - needed),

--- a/bot/src/tactician.rs
+++ b/bot/src/tactician.rs
@@ -1,20 +1,20 @@
 //! `TacticianBot`: a scripted heuristic that beats `GreedyBot`.
 //!
 //! Under the v1 rules a careful player wins the two-player game
-//! without ever breaking a defense:
+//! without ever breaking a garrison:
 //! games are decided on tile count at `Config::max_turns`,
 //! and a frontier garrison the command-point-capped attacker cannot
 //! out-fund holds indefinitely
-//! (why this favours the defender: `DESIGN.md`, "Why turtling dominates";
+//! (why this favours the holder: `DESIGN.md`, "Why turtling dominates";
 //! the combat that makes a held tile stick is `GameState::step`).
 //! So the tactician wins the neutral land grab and holds it,
-//! instead of trading armies into the defense bonus like `GreedyBot`.
+//! instead of trading armies into a full-strength garrison like `GreedyBot`.
 //!
 //! Three things distinguish it from `GreedyBot`:
 //!
 //! - Command-point-aware funding (`crate::take_budget_floored`):
 //!   an attack is kept only when the pool will actually pay for a force
-//!   that still beats the defender,
+//!   that still out-presents the garrison,
 //!   never the under-funded overrun `GreedyBot` throws away.
 //! - It claims neutral tiles toward the map centre first
 //!   — the ground both players race for —
@@ -68,13 +68,11 @@ impl TacticianBot {
     }
 
     /// The garrison that survives `threat` incoming armies with a unit to
-    /// spare: the smallest `g` with `g * defense_bonus_pct / 100 > threat`.
+    /// spare: the smallest `g` with `g > threat`, i.e. `threat + 1`.
     /// A tile held this strongly keeps both its ownership
-    /// and a defending army through one maximal enemy turn.
-    fn garrison_to_hold(state: &GameState, threat: u64) -> u64 {
-        let bonus = state.config.defense_bonus_pct as u64;
-        // Smallest g with g*bonus/100 > threat  <=>  g*bonus > threat*100.
-        (threat * 100) / bonus + 1
+    /// and a surviving garrison through one maximal enemy turn.
+    fn garrison_to_hold(threat: u64) -> u64 {
+        threat + 1
     }
 }
 
@@ -85,7 +83,6 @@ impl Bot for TacticianBot {
 
     fn orders(&mut self, state: &GameState, me: PlayerId) -> Vec<Order> {
         let frontier = frontier_distances(state, me);
-        let bonus = state.config.defense_bonus_pct as i64;
         let radius = state.config.radius;
         let center = Hex::new(0, 0);
         let mut candidates: Vec<Candidate> = Vec::new();
@@ -103,7 +100,7 @@ impl Bot for TacticianBot {
             // exposed the tile, the earlier it is funded.
             if threatened
                 && tile.resources > 0
-                && (tile.army as u64) < Self::garrison_to_hold(state, threat)
+                && (tile.army as u64) < Self::garrison_to_hold(threat)
             {
                 candidates.push(Candidate {
                     priority: 1000 + threat as i64,
@@ -147,10 +144,10 @@ impl Bot for TacticianBot {
                     // Enemy tile: rank a capture (a two-tile swing) by how
                     // cheap the kill is. The `needed` floor is what makes the
                     // attack safe — the funding pass drops it unless the pool
-                    // pays for a force that strictly beats the bonus-scaled
-                    // defender, so an under-funded attack is never issued.
+                    // pays for a force that strictly outnumbers the garrison,
+                    // so an under-funded attack is never issued.
                     Some(owner) if owner != me => {
-                        let needed = (next.army as i64 * bonus) / 100 + 1;
+                        let needed = next.army as i64 + 1;
                         if (tile.army as i64) >= needed {
                             candidates.push(Candidate {
                                 priority: 800 - needed,

--- a/bot/tests/health.rs
+++ b/bot/tests/health.rs
@@ -56,7 +56,7 @@ fn greedy_dominates_random_by_elimination() {
 /// The scripted ladder must have a top rung:
 /// `tactician` beats `greedy` decisively from either seat.
 /// It wins the neutral land grab and holds it to the tile-count adjudication
-/// rather than trading into the defense bonus,
+/// rather than trading into a full-strength garrison,
 /// so — like every `greedy` mirror — these games run to the turn limit;
 /// the win shows up in the standings, not in eliminations.
 /// Guards against a change that lets `greedy`

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -47,8 +47,6 @@ pub struct Config {
     /// settling at the emergent cap `Config::resource_equilibrium`.
     /// A percentage, so it must be in `1..=100`.
     pub maintenance_pct: u32,
-    /// Defender strength multiplier in percent (125 = 1.25x).
-    pub defense_bonus_pct: u32,
 }
 
 impl Config {
@@ -73,7 +71,6 @@ impl Default for Config {
             initial_resources: 10,
             production: 2,
             maintenance_pct: 2,
-            defense_bonus_pct: 125,
         }
     }
 }
@@ -354,8 +351,11 @@ impl GameState {
     /// processing order is irrelevant: departures and recruits happen
     /// "at once", then everything lands and fights, then resources flow
     /// (production minus maintenance).
-    /// One order per tile per turn also means recruited armies defend
-    /// immediately but cannot move until the next turn.
+    /// Combat is mutual attack with no defense: only armies commanded to
+    /// move strike, so a stationary garrison deals no damage and a winning
+    /// attacker keeps its full force (see the combat step below).
+    /// One order per tile per turn also means recruited armies join the
+    /// garrison immediately but cannot move until the next turn.
     pub fn step(&mut self, orders: &[Vec<Order>]) -> Outcome {
         assert_eq!(orders.len(), self.config.players as usize);
 
@@ -409,59 +409,57 @@ impl GameState {
             }
         }
 
-        let defense_bonus_pct = self.config.defense_bonus_pct as u64;
-        for (dst, mut parties) in arrivals {
+        for (dst, parties) in arrivals {
             let tile = &mut self.tiles[dst];
             // Neutral tiles never hold armies (ownership never reverts), so
             // there is no "neutral garrison" party to account for.
             debug_assert!(tile.owner.is_some() || tile.army == 0);
 
-            // The defender's party is the garrison plus any same-owner
-            // arrivals; the whole party gets the defense bonus.
-            if let Some(owner) = tile.owner {
-                *parties.entry(owner).or_default() += tile.army as u64;
+            // There is no defense, only mutual attack: a stationary garrison
+            // deals no damage — to strike, an army must be ordered to move.
+            // Track each party as (player, presence, attack): presence
+            // (arrivals, plus the owner's garrison) decides who holds the
+            // tile; attack (arrivals alone) is what costs the others armies.
+            let owner = tile.owner;
+            let mut forces: Vec<(PlayerId, u64, u64)> =
+                parties.into_iter().map(|(p, arr)| (p, arr, arr)).collect();
+            // Fold the owner's garrison into its presence, adding the owner as
+            // a pure-garrison party when it commanded no arrivals of its own.
+            let garrison = tile.army as u64;
+            if let Some(o) = owner.filter(|_| garrison > 0) {
+                match forces.iter_mut().find(|f| f.0 == o) {
+                    Some(f) => f.1 += garrison,
+                    None => forces.push((o, garrison, 0)),
+                }
             }
-            let defender = tile.owner;
 
-            if parties.len() == 1 {
-                let (player, amount) = parties.into_iter().next().unwrap();
+            if forces.len() == 1 {
+                let (player, present, _) = forces[0];
                 tile.owner = Some(player);
-                tile.army = amount.min(u32::MAX as u64) as u32;
+                tile.army = present.min(u32::MAX as u64) as u32;
                 continue;
             }
 
-            // Deterministic single-step combat: the strongest party survives,
-            // paying the combined effective strength of everyone else.
-            let effective = |p: PlayerId, actual: u64| -> u64 {
-                if Some(p) == defender {
-                    actual * defense_bonus_pct / 100
-                } else {
-                    actual
-                }
-            };
-            let mut ranked: Vec<(PlayerId, u64, u64)> = parties
-                .iter()
-                .map(|(&p, &a)| (p, a, effective(p, a)))
-                .collect();
-            // Strongest first; player id breaks ties deterministically.
-            ranked.sort_by_key(|&(p, _, eff)| (std::cmp::Reverse(eff), p));
+            // Deterministic single-step combat: the largest presence holds the
+            // tile, paying only the combined attack of everyone else — a
+            // garrison strikes for nothing, so overrunning it is free. The
+            // owner wins ties, so an attacker that merely matches a garrison
+            // annihilates against it rather than taking the tile.
+            forces
+                .sort_by_key(|&(p, present, _)| (std::cmp::Reverse(present), Some(p) != owner, p));
 
-            let (winner, winner_actual, winner_eff) = ranked[0];
-            let losses_eff: u64 = ranked[1..].iter().map(|&(_, _, eff)| eff).sum();
+            let (winner, winner_present, _) = forces[0];
+            let losses: u64 = forces[1..].iter().map(|&(_, _, attack)| attack).sum();
 
-            if winner_eff <= losses_eff {
-                // Mutual annihilation (covers exact ties for first place,
-                // since the runner-up alone already matches winner_eff):
-                // tile keeps its owner but is left undefended.
+            if winner_present <= losses {
+                // Mutual annihilation (covers a tie for the largest presence,
+                // since the runner-up's attack alone then matches the winner):
+                // the tile keeps its owner but is left undefended.
                 tile.army = 0;
                 continue;
             }
-            // Convert the winner's surviving effective strength back to
-            // actual units (u128: the product can exceed u64 for huge armies).
-            let surviving =
-                (winner_eff - losses_eff) as u128 * winner_actual as u128 / winner_eff as u128;
             tile.owner = Some(winner);
-            tile.army = surviving.min(u32::MAX as u128) as u32;
+            tile.army = (winner_present - losses).min(u32::MAX as u64) as u32;
         }
 
         // Flat production minus stockpile-scaled maintenance; converges up to
@@ -723,31 +721,51 @@ mod tests {
     }
 
     #[test]
-    fn defender_with_bonus_repels_equal_attack() {
+    fn equal_attack_annihilates_both_sides() {
         let mut s = state();
         let initial = s.config.initial_army;
         let (p0_start, attacker_hex, back) = stage_attack(&mut s, initial);
 
         s.step(&[vec![], vec![move_all(attacker_hex, back)]]);
 
-        // Equal armies, but the defender's 1.25x bonus wins the fight.
+        // The attacker only matches the garrison, so neither holds the tile:
+        // it stays the owner's but is left undefended.
         let defended = s.tile(p0_start).unwrap();
         assert_eq!(defended.owner, Some(PlayerId(0)));
-        assert!(defended.army > 0);
-        assert!(defended.army < s.config.initial_army);
+        assert_eq!(defended.army, 0);
     }
 
     #[test]
-    fn overwhelming_attack_conquers() {
+    fn understrength_attack_leaves_the_garrison_standing() {
         let mut s = state();
         let initial = s.config.initial_army;
-        let (p0_start, attacker_hex, back) = stage_attack(&mut s, initial * 10);
+        // Attacker musters one fewer army than the garrison it charges.
+        let (p0_start, attacker_hex, back) = stage_attack(&mut s, initial - 1);
 
         s.step(&[vec![], vec![move_all(attacker_hex, back)]]);
 
+        // The garrison took the attacker's fire and holds with what is left
+        // (initial - (initial - 1) = 1).
+        let defended = s.tile(p0_start).unwrap();
+        assert_eq!(defended.owner, Some(PlayerId(0)));
+        assert_eq!(defended.army, 1);
+    }
+
+    #[test]
+    fn winning_attacker_keeps_its_full_force() {
+        let mut s = state();
+        let initial = s.config.initial_army;
+        // One army over the garrison is enough to take the tile.
+        let attackers = initial + 1;
+        let (p0_start, attacker_hex, back) = stage_attack(&mut s, attackers);
+
+        s.step(&[vec![], vec![move_all(attacker_hex, back)]]);
+
+        // The garrison dealt no damage, so the attacker keeps every army it
+        // brought — the whole point of "no defense, only mutual attack".
         let taken = s.tile(p0_start).unwrap();
         assert_eq!(taken.owner, Some(PlayerId(1)));
-        assert!(taken.army > 0);
+        assert_eq!(taken.army, attackers);
         // Player 0 lost their only tile: game over.
         assert_eq!(s.outcome(), Outcome::Winner(PlayerId(1)));
     }
@@ -767,10 +785,11 @@ mod tests {
 
         s.step(&[vec![], vec![move_all(attacker_hex, back)]]);
 
+        // The garrison strikes for nothing, so a u32::MAX attacker survives at
+        // full strength — the count is clamped to the tile's u32, not wrapped.
         let taken = s.tile(p0_start).unwrap();
         assert_eq!(taken.owner, Some(PlayerId(1)));
-        assert!(taken.army > 0);
-        assert!(taken.army < u32::MAX);
+        assert_eq!(taken.army, u32::MAX);
     }
 
     #[test]

--- a/engine/tests/invariants.rs
+++ b/engine/tests/invariants.rs
@@ -180,4 +180,4 @@ fn golden_game_final_state_is_pinned() {
 }
 
 const GOLDEN_TURNS: u32 = 200;
-const GOLDEN_HASH: u64 = 1061877323026431320;
+const GOLDEN_HASH: u64 = 237611136291689839;


### PR DESCRIPTION
## Summary

Removes the `defense_bonus_pct` configuration and the concept of auto-defending garrisons.
A stationary garrison now deals no damage in combat — only armies commanded to move strike.
This simplifies combat to pure mutual attack: the largest presence holds the tile, paying only the combined attack of everyone else.

## Changes

- **Config**: Removed `defense_bonus_pct` field and its default value (125).
- **Combat mechanics**: Replaced the effective-strength model (where defenders got a 1.25x multiplier) with a simpler presence-vs-attack model:
  - Each party tracks presence (arrivals + garrison for the owner) and attack (arrivals alone).
  - The largest presence wins the tile.
  - Losses are paid only in attack values, not presence — so a garrison that doesn't move inflicts no casualties.
  - A winning attacker keeps its full force (since the garrison struck for nothing).
  - Mutual annihilation occurs when the winner's presence ≤ combined attack of all others.
- **Tests**: Updated three combat tests to reflect the new rules:
  - `defender_with_bonus_repels_equal_attack` → `equal_attack_annihilates_both_sides`: equal armies now annihilate rather than the defender winning.
  - Added `understrength_attack_leaves_the_garrison_standing`: confirms a garrison survives when the attack is smaller.
  - `overwhelming_attack_conquers` → `winning_attacker_keeps_its_full_force`: confirms the attacker retains all armies when it wins.
- **Bots**: Simplified `TacticianBot` and `GreedyBot` to remove defense-bonus calculations; `garrison_to_hold` now simply returns `threat + 1`.
- **Docs**: Updated `DESIGN.md` and bot comments to reflect that a garrison is presence to out-deliver, not an army that fights back; added a decision note explaining the rationale and open questions about whether this loosens the turtle.
- **Golden test**: Updated hash to reflect new combat outcomes.

## Rationale

The defense bonus was part of the "turtling dominates" problem: a garrison could hold indefinitely because it fought back at 1.25x strength.
Removing auto-defense and the bonus simplifies the model while keeping the structural reason the turtle survives (the per-turn command-point pool caps delivery to any one tile, so a pool-sized garrison still cannot be taken in a single turn).
Whether this change actually loosens the turtle is open and should be tested with a dedicated turtle-breaker bot.

https://claude.ai/code/session_0191513NSUJhxH6BF29ohHmu